### PR TITLE
Do the groundwork for moving seller data to the SellerVersion

### DIFF
--- a/app/models/concerns/seller_version_aliases.rb
+++ b/app/models/concerns/seller_version_aliases.rb
@@ -1,0 +1,68 @@
+module Concerns::SellerVersionAliases
+  extend ActiveSupport::Concern
+
+  FIELDS = [
+    :name,
+    :abn,
+    :summary,
+    :services,
+    :govdc,
+    :website_url,
+    :linkedin_url,
+    :number_of_employees,
+    :corporate_structure,
+    :start_up,
+    :sme,
+    :not_for_profit,
+    :regional,
+    :disability,
+    :female_owned,
+    :indigenous,
+    :australian_owned,
+    :no_experience,
+    :local_government_experience,
+    :state_government_experience,
+    :federal_government_experience,
+    :international_government_experience,
+    :contact_name,
+    :contact_email,
+    :contact_phone,
+    :representative_name,
+    :representative_email,
+    :representative_phone,
+    :representative_position,
+    :investigations,
+    :legal_proceedings,
+    :insurance_claims,
+    :conflicts_of_interest,
+    :other_circumstances,
+    :receivership,
+    :investigations_details,
+    :legal_proceedings_details,
+    :insurance_claims_details,
+    :conflicts_of_interest_details,
+    :other_circumstances_details,
+    :receivership_details,
+    :financial_statement_expiry,
+    :professional_indemnity_certificate_expiry,
+    :workers_compensation_certificate_expiry,
+    :workers_compensation_exempt,
+    :product_liability_certificate_expiry,
+    :agree,
+    :agreed_at,
+    :agreed_by_id,
+  ]
+
+  def propagate_changes_to_version!
+    if first_version.present?
+      first_version.update_attributes!(
+        self.attributes.symbolize_keys.slice(*FIELDS)
+      )
+    end
+  end
+
+  included do
+    after_save :propagate_changes_to_version!
+  end
+
+end

--- a/app/models/seller.rb
+++ b/app/models/seller.rb
@@ -3,6 +3,7 @@ class Seller < ApplicationRecord
   extend Enumerize
 
   include Concerns::Documentable
+  include Concerns::SellerVersionAliases
   include Concerns::StateScopes
 
   has_many :owners, class_name: 'User'
@@ -58,6 +59,10 @@ class Seller < ApplicationRecord
 
   def version_in_progress?
     versions.created.any?
+  end
+
+  def first_version
+    versions.first
   end
 
   private

--- a/db/migrate/20180706050123_add_seller_fields_to_seller_versions.rb
+++ b/db/migrate/20180706050123_add_seller_fields_to_seller_versions.rb
@@ -1,0 +1,64 @@
+class AddSellerFieldsToSellerVersions < ActiveRecord::Migration[5.1]
+  def change
+    change_table :seller_versions do |t|
+      t.string :name
+      t.string :abn
+      t.text :summary
+
+      t.text :services, default: [], array: true
+      t.boolean :govdc
+
+      t.string :website_url
+      t.string :linkedin_url
+
+      t.string :number_of_employees
+      t.string :corporate_structure
+      t.boolean :start_up
+      t.boolean :sme
+      t.boolean :not_for_profit
+      t.boolean :regional
+      t.boolean :disability
+      t.boolean :female_owned
+      t.boolean :indigenous
+      t.boolean :australian_owned
+
+      t.boolean :no_experience
+      t.boolean :local_government_experience
+      t.boolean :state_government_experience
+      t.boolean :federal_government_experience
+      t.boolean :international_government_experience
+
+      t.string :contact_name
+      t.string :contact_email
+      t.string :contact_phone
+      t.string :representative_name
+      t.string :representative_email
+      t.string :representative_phone
+      t.string :representative_position
+
+      t.boolean :investigations
+      t.boolean :legal_proceedings
+      t.boolean :insurance_claims
+      t.boolean :conflicts_of_interest
+      t.boolean :other_circumstances
+      t.boolean :receivership
+
+      t.text :investigations_details
+      t.text :legal_proceedings_details
+      t.text :insurance_claims_details
+      t.text :conflicts_of_interest_details
+      t.text :other_circumstances_details
+      t.text :receivership_details
+
+      t.date :financial_statement_expiry
+      t.date :professional_indemnity_certificate_expiry
+      t.date :workers_compensation_certificate_expiry
+      t.boolean :workers_compensation_exempt
+      t.date :product_liability_certificate_expiry
+
+      t.boolean :agree
+      t.datetime :agreed_at
+      t.integer :agreed_by_id
+    end
+  end
+end

--- a/db/migrate/20180706050520_propagate_seller_details_to_seller_versions.rb
+++ b/db/migrate/20180706050520_propagate_seller_details_to_seller_versions.rb
@@ -6,6 +6,6 @@ class PropagateSellerDetailsToSellerVersions < ActiveRecord::Migration[5.1]
   end
 
   def down
-    puts "PropagateSellerDetailsToSellerVersions cannot be reversed"
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20180706050520_propagate_seller_details_to_seller_versions.rb
+++ b/db/migrate/20180706050520_propagate_seller_details_to_seller_versions.rb
@@ -1,0 +1,11 @@
+class PropagateSellerDetailsToSellerVersions < ActiveRecord::Migration[5.1]
+  def up
+    Seller.all.each {|seller|
+      seller.propagate_changes_to_version!
+    }
+  end
+
+  def down
+    puts "PropagateSellerDetailsToSellerVersions cannot be reversed"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180706050123) do
+ActiveRecord::Schema.define(version: 20180706050520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180706043159) do
+ActiveRecord::Schema.define(version: 20180706050123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -295,6 +295,55 @@ ActiveRecord::Schema.define(version: 20180706043159) do
     t.integer "seller_id", null: false
     t.integer "assigned_to_id"
     t.boolean "tailor_complete", default: false
+    t.string "name"
+    t.string "abn"
+    t.text "summary"
+    t.text "services", default: [], array: true
+    t.boolean "govdc"
+    t.string "website_url"
+    t.string "linkedin_url"
+    t.string "number_of_employees"
+    t.string "corporate_structure"
+    t.boolean "start_up"
+    t.boolean "sme"
+    t.boolean "not_for_profit"
+    t.boolean "regional"
+    t.boolean "disability"
+    t.boolean "female_owned"
+    t.boolean "indigenous"
+    t.boolean "australian_owned"
+    t.boolean "no_experience"
+    t.boolean "local_government_experience"
+    t.boolean "state_government_experience"
+    t.boolean "federal_government_experience"
+    t.boolean "international_government_experience"
+    t.string "contact_name"
+    t.string "contact_email"
+    t.string "contact_phone"
+    t.string "representative_name"
+    t.string "representative_email"
+    t.string "representative_phone"
+    t.string "representative_position"
+    t.boolean "investigations"
+    t.boolean "legal_proceedings"
+    t.boolean "insurance_claims"
+    t.boolean "conflicts_of_interest"
+    t.boolean "other_circumstances"
+    t.boolean "receivership"
+    t.text "investigations_details"
+    t.text "legal_proceedings_details"
+    t.text "insurance_claims_details"
+    t.text "conflicts_of_interest_details"
+    t.text "other_circumstances_details"
+    t.text "receivership_details"
+    t.date "financial_statement_expiry"
+    t.date "professional_indemnity_certificate_expiry"
+    t.date "workers_compensation_certificate_expiry"
+    t.boolean "workers_compensation_exempt"
+    t.date "product_liability_certificate_expiry"
+    t.boolean "agree"
+    t.datetime "agreed_at"
+    t.integer "agreed_by_id"
   end
 
   create_table "sellers", force: :cascade do |t|

--- a/spec/models/seller_spec.rb
+++ b/spec/models/seller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Seller do
 
     it "should not normalise an invalid value" do
       seller = create(:inactive_seller_with_full_profile, abn: "1234")
-      expect(seller.abn).to eq("1234")      
+      expect(seller.abn).to eq("1234")
     end
 
     # This is actually testing the factory
@@ -26,6 +26,18 @@ RSpec.describe Seller do
       expect(ABN.valid?(seller1.abn)).to be_truthy
       expect(ABN.valid?(seller2.abn)).to be_truthy
       expect(ABN.valid?(seller3.abn)).to be_truthy
+    end
+  end
+
+  describe '#propagate_changes_to_version!' do
+    let!(:seller) { create(:seller) }
+    let!(:version) { create(:seller_version, seller: seller) }
+
+    it 'updates the version on save with the same attributes' do
+      seller.update_attributes!(name: 'An updated name')
+      version.reload
+
+      expect(version.name).to eq('An updated name')
     end
   end
 end


### PR DESCRIPTION
This does preparatory work for moving seller data from the `Seller` model to `SellerVersion`.

This branch:

- adds the seller fields from the `sellers` table to `seller_versions`
- inserts a callback to the `Seller` model to sync data to the `SellerVersion` on save
- runs a data migration to run the sync once over all the existing sellers