### PR TITLE
Fix searching by seller name in the Ops application view

### DIFF
--- a/app/models/search/ops/seller_version.rb
+++ b/app/models/search/ops/seller_version.rb
@@ -39,7 +39,7 @@ module Search::Ops
     def name_filter(relation)
       if filter_selected?(:name)
         term = filter_value(:name)
-        relation.joins(:seller).basic_search(sellers: { name: term })
+        relation.basic_search(name: term)
       else
         relation
       end

--- a/spec/models/search/ops/seller_version_spec.rb
+++ b/spec/models/search/ops/seller_version_spec.rb
@@ -55,4 +55,17 @@ RSpec.describe Search::Ops::SellerVersion do
     expect(search.results.size).to eq(5)
   end
 
+  it 'filters by name' do
+    create_list(:seller_version, 5, name: 'Foo')
+    create_list(:seller_version, 3, name: 'Bar')
+
+    search = described_class.new(
+      selected_filters: {
+        name: 'Bar'
+      }
+    )
+
+    expect(search.results.size).to eq(3)
+  end
+
 end


### PR DESCRIPTION
One thing I missed in #282 was updating the seller application search in the Ops view, which was still searching on the name in the `sellers` table, not `seller_versions`. 

This updates the behaviour of the `Search::Ops::SellerVersion` class to search on the correct table.