### PR TITLE
Reimplement seller detail porting behaviour on migration

### DIFF
--- a/db/migrate/20180706050520_propagate_seller_details_to_seller_versions.rb
+++ b/db/migrate/20180706050520_propagate_seller_details_to_seller_versions.rb
@@ -1,7 +1,65 @@
 class PropagateSellerDetailsToSellerVersions < ActiveRecord::Migration[5.1]
+
+  FIELDS = [
+    :name,
+    :abn,
+    :summary,
+    :services,
+    :govdc,
+    :website_url,
+    :linkedin_url,
+    :number_of_employees,
+    :corporate_structure,
+    :start_up,
+    :sme,
+    :not_for_profit,
+    :regional,
+    :disability,
+    :female_owned,
+    :indigenous,
+    :australian_owned,
+    :no_experience,
+    :local_government_experience,
+    :state_government_experience,
+    :federal_government_experience,
+    :international_government_experience,
+    :contact_name,
+    :contact_email,
+    :contact_phone,
+    :representative_name,
+    :representative_email,
+    :representative_phone,
+    :representative_position,
+    :investigations,
+    :legal_proceedings,
+    :insurance_claims,
+    :conflicts_of_interest,
+    :other_circumstances,
+    :receivership,
+    :investigations_details,
+    :legal_proceedings_details,
+    :insurance_claims_details,
+    :conflicts_of_interest_details,
+    :other_circumstances_details,
+    :receivership_details,
+    :financial_statement_expiry,
+    :professional_indemnity_certificate_expiry,
+    :workers_compensation_certificate_expiry,
+    :workers_compensation_exempt,
+    :product_liability_certificate_expiry,
+    :agree,
+    :agreed_at,
+    :agreed_by_id,
+  ]
+
   def up
     Seller.all.each {|seller|
-      seller.propagate_changes_to_version!
+      if seller.first_version.present?
+        seller.first_version.update_attributes!(
+          seller.attributes.symbolize_keys.slice(*FIELDS)
+        )
+        puts "Updated: Seller ##{seller.id} => SellerVersion ##{seller.first_version.id}"
+      end
     }
   end
 


### PR DESCRIPTION
Removing the `propagate_changes_to_version!` method from the `Concerns::SellerVersionAliases` in #282 broke the previous migration.

We aren't adding the method back, instead implementing it directly on the migration (along with the list of fields) so it will last into the future.