### PR TITLE
Improve problem reports

### DIFF
--- a/app/controllers/feedback/problem_reports_controller.rb
+++ b/app/controllers/feedback/problem_reports_controller.rb
@@ -1,10 +1,13 @@
 class Feedback::ProblemReportsController < ApplicationController
 
   def create
-    item = ProblemReport.create(report_params)
+    operation = CreateProblemReport.call(
+      params: params,
+      current_user: current_user,
+    )
 
     respond_to do |format|
-      if item.persisted?
+      if operation.success?
         format.html {
           flash.notice = success_message
           redirect_to(root_path)
@@ -22,17 +25,6 @@ class Feedback::ProblemReportsController < ApplicationController
   end
 
 private
-  def report_params
-    {
-      task: params[:task],
-      issue: params[:issue],
-      url: params[:url],
-      referer: params[:referer],
-      browser: params[:browser],
-      user: (current_user if current_user.present?),
-    }
-  end
-
   def success_message
     I18n.t('feedback.problem_report.messages.success')
   end

--- a/app/services/create_problem_report.rb
+++ b/app/services/create_problem_report.rb
@@ -9,6 +9,7 @@ class CreateProblemReport < ApplicationService
     begin
       assign_attributes
       persist_problem_report
+      send_slack_notification
 
       self.state = :success
     rescue Failure
@@ -40,6 +41,10 @@ private
 
   def persist_problem_report
     raise Failure unless problem_report.save
+  end
+
+  def send_slack_notification
+    SlackPostJob.perform_later(problem_report.id, :new_problem_report.to_s)
   end
 
 end

--- a/app/services/create_problem_report.rb
+++ b/app/services/create_problem_report.rb
@@ -1,0 +1,45 @@
+class CreateProblemReport < ApplicationService
+
+  def initialize(params:, current_user: nil)
+    @params = params
+    @current_user = current_user
+  end
+
+  def call
+    begin
+      assign_attributes
+      persist_problem_report
+
+      self.state = :success
+    rescue Failure
+      self.state = :failure
+    end
+  end
+
+  def problem_report
+    @problem_report ||= ProblemReport.new
+  end
+
+private
+  attr_reader :params, :current_user
+
+  def report_params
+    {
+      task: params[:task],
+      issue: params[:issue],
+      url: params[:url],
+      referer: params[:referer],
+      browser: params[:browser],
+      user: current_user,
+    }
+  end
+
+  def assign_attributes
+    problem_report.assign_attributes(report_params)
+  end
+
+  def persist_problem_report
+    raise Failure unless problem_report.save
+  end
+
+end

--- a/app/views/ops/problem_reports/_reports_list.html.erb
+++ b/app/views/ops/problem_reports/_reports_list.html.erb
@@ -18,7 +18,7 @@
         <tr>
           <td><%= report.id %></td>
           <td><%= report.state %></td>
-          <td><%= report.url.sub(/\Ahttps?\:\/\/[a-z0-9:\.]+\//, '/') %></td>
+          <td><%= report.url&.sub(/\Ahttps?\:\/\/[a-z0-9:\.]+\//, '/') %></td>
           <td><%= report.issue %></td>
           <td>
             <%= report.tags.join(', ') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -247,3 +247,6 @@ en:
     seller_version_submitted:
       text: "%{seller} just submitted an application to become a seller. :rainbow: :tada:"
       button: Review application
+    new_problem_report:
+      text: "A new problem was reported :mega: :speech_balloon:"
+      button: "View problem report"

--- a/spec/factories/problem_reports.rb
+++ b/spec/factories/problem_reports.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :problem_report do
     task 'try to do something'
-    issue 'it does not work'
+    sequence(:issue) {|n| "For #{n} times it does not work" }
     browser 'ExampleBrowser 5/1.2.3'
     url 'http://example.org/cloud'
     referer 'http://example.org/referer'

--- a/spec/features/ops_problem_reporting_spec.rb
+++ b/spec/features/ops_problem_reporting_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Submitting a problem report', type: :feature, js: true do
   let(:updated_message) { I18n.t('ops.problem_reports.messages.updated') }
 
   let!(:report) { create(:problem_report) }
+  let!(:reports) { create_list(:problem_report, 10, url: nil) }
   let(:tags) { ['example', 'tags'] }
 
   describe 'as an admin user', user: :admin_user do

--- a/spec/services/create_problem_report_spec.rb
+++ b/spec/services/create_problem_report_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe CreateProblemReport do
+
+  let(:params) {
+    {
+      task: 'task',
+      issue: 'issue',
+      url: 'http://example.org',
+      referer: 'http://example.org/referer',
+      browser: 'ExampleBrowser/10.0',
+    }
+  }
+  let(:user) { create(:seller_user) }
+
+  describe '.call' do
+    context 'with valid attributes' do
+      let(:operation) {
+        described_class.call(params: params, current_user: nil)
+      }
+
+      it 'is successful' do
+        expect(operation).to be_success
+      end
+
+      it 'creates the report' do
+        report = operation.problem_report.reload
+
+        expect(report.task).to eq(params[:task])
+        expect(report.issue).to eq(params[:issue])
+        expect(report.url).to eq(params[:url])
+        expect(report.referer).to eq(params[:referer])
+        expect(report.browser).to eq(params[:browser])
+      end
+    end
+
+    context 'with a user object' do
+      let(:operation) {
+        described_class.call(params: params, current_user: user)
+      }
+
+      it 'assigns the user' do
+        report = operation.problem_report.reload
+        expect(report.user).to eq(user)
+      end
+    end
+
+    context 'with invalid attributes' do
+      let(:operation) {
+        described_class.call(params: params.merge(task: nil, issue: nil), current_user: nil)
+      }
+
+      it 'fails' do
+        expect(operation).to be_failure
+      end
+    end
+  end
+
+end

--- a/spec/services/create_problem_report_spec.rb
+++ b/spec/services/create_problem_report_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe CreateProblemReport do
         expect(report.referer).to eq(params[:referer])
         expect(report.browser).to eq(params[:browser])
       end
+
+      it 'notifies slack of the problem report' do
+        expect(SlackPostJob).to receive(:perform_later)
+        operation
+      end
     end
 
     context 'with a user object' do


### PR DESCRIPTION
This improves how problem reports are handled on buy.nsw, including:

1. fixing an issue where an empty URL raises an exception on the reports list
2. adding a service object for creating a problem report
3. sending a Slack notification when a problem report is received 🎉 