### PR TITLE
Migrate awards, accreditations and engagements to seller versions

### DIFF
--- a/app/assets/javascripts/modules/detailed_expanding_list.js
+++ b/app/assets/javascripts/modules/detailed_expanding_list.js
@@ -1,0 +1,228 @@
+(function () {
+  'use strict'
+  window.ProcurementHub = window.ProcurementHub || {}
+
+  function DetailedExpandingListModule (options) {
+    this.$el = options.$el
+    this.$template = this.buildTemplateForm()
+    this.$container = this.$el.find('ol')
+
+    this.inlineLabels = this.hasInlineLabels()
+    this.objectName = this.$el.attr('data-object-name')
+    this.maxItems = this.$el.attr('data-expanding-list-max')
+
+    if (this.objectName == null) {
+      this.objectName = 'row'
+    }
+
+    this.$addLink = this.buildAddLink()
+
+    this.setupForm()
+  }
+
+  DetailedExpandingListModule.prototype.setupForm = function setupForm () {
+    this.$el.addClass('expanding-list')
+
+    if (!this.listFull()) {
+      this.insertAddLink()
+    }
+
+    // Only add delete links to the rows which exist in the database, not new
+    // empty ones. We can check for this by finding the ones which have an
+    // existing value in the 'id' hidden field.
+    //
+    var $rows = this.$container.find('li:has(input[type=hidden][value])')
+    $($rows).each(
+      $.proxy(this.buildDeleteLink, this)
+    )
+  }
+
+  DetailedExpandingListModule.prototype.addNewRow = function addNewRow (event) {
+    event.preventDefault()
+
+    if (this.listFull() === true) {
+      return false
+    }
+
+    var $newRow = this.$template.clone()
+
+    var $visibleInputs = $newRow.find('input[type=text], select')
+    var $hiddenInput = $newRow.find('input[type=hidden]')
+
+    var newIndex = this.getNewIndex()
+    var visibleIndex = newIndex + 1
+
+    $visibleInputs.each($.proxy(function (i, input) {
+      var $input = $(input)
+      var $label = $input.siblings('label')
+
+      if (this.inlineLabels === true) {
+        $label.text(visibleIndex + '.')
+      }
+      $label.attr('for', this.buildFieldID(
+        $input.attr('id'), newIndex
+      ))
+
+      $input.attr('name', this.buildFieldName(
+        $input.attr('name'), newIndex
+      ))
+      $input.attr('id', this.buildFieldID(
+        $input.attr('id'), newIndex
+      ))
+    }, this))
+
+    $hiddenInput.attr('name', this.buildFieldName(
+      $hiddenInput.attr('name'), newIndex
+    ))
+    $hiddenInput.attr('id', this.buildFieldID(
+      $hiddenInput.attr('id'), newIndex
+    ))
+
+    $newRow.appendTo(this.$container)
+    $visibleInputs.first().focus()
+
+    if (this.listFull()) {
+      this.removeAddLink()
+    }
+  }
+
+  DetailedExpandingListModule.prototype.listFull = function listFull () {
+    return (this.maxItems !== null && this.$container.find('li:not(.removed)').length >= this.maxItems)
+  }
+
+  DetailedExpandingListModule.prototype.deleteRow = function deleteRow ($row, event) {
+    event.preventDefault()
+
+    var $inputField = $row.find('input[type=text], select')
+    var $deleteLink = $row.find('a')
+
+    $row.addClass('removed')
+    $inputField.attr('disabled', true)
+    $deleteLink.remove()
+
+    if (this.listFull() === false) {
+      this.insertAddLink()
+    }
+  }
+
+  DetailedExpandingListModule.prototype.buildAddLink = function buildAddLink () {
+    var $addLink = $('<a></a>')
+    $addLink.text('Add another ' + this.objectName)
+    $addLink.attr('href', '#')
+
+    return $addLink
+  }
+
+  DetailedExpandingListModule.prototype.insertAddLink = function insertAddLink () {
+    // Always remove the link to avoid doubling-up
+    this.$addLink.remove()
+
+    this.$addLink.appendTo(this.$el)
+    this.$addLink.on('click', $.proxy(this.addNewRow, this))
+  }
+
+  DetailedExpandingListModule.prototype.removeAddLink = function removeAddLink () {
+    this.$addLink.remove()
+  }
+
+  DetailedExpandingListModule.prototype.buildDeleteLink = function buildDeleteLink (i, element) {
+    var $deleteContainer = $('<div></div>').addClass('delete-action')
+    var $deleteLink = $('<a></a>')
+    var $element = $(element)
+
+    $deleteLink.text('Delete this ' + this.objectName)
+    $deleteLink.attr('href', '#')
+    $deleteLink.on('click', $.proxy(this.deleteRow, this, $element))
+
+    $deleteLink.appendTo($deleteContainer)
+    $deleteContainer.appendTo($element)
+  }
+
+  DetailedExpandingListModule.prototype.buildTemplateForm = function buildTemplateForm () {
+    var $templateForm = this.$el.find('li:first-of-type').clone()
+
+    var $textInput = $templateForm.find('input[type=text]')
+    var $selectInput = $templateForm.find('select')
+    var $hiddenInput = $templateForm.find('input[type=hidden]')
+
+    $textInput.val('')
+    $hiddenInput.val('')
+
+    // Reset the selected value in any dropdown boxes
+    $.each($selectInput, function (i, item) {
+      var $item = $(item)
+      var defaultVal = $item.attr('data-expanding-list-default')
+
+      $item.find('option').removeAttr('selected')
+      if (defaultVal !== undefined) {
+        $item.find('option[value="' + defaultVal + '"]').attr('selected', true)
+      } else {
+        $item.find('option:first').attr('selected', true)
+      }
+    })
+
+    return $templateForm
+  }
+
+  DetailedExpandingListModule.prototype.buildFieldName = function buildFieldName (name, newIndex) {
+    // The following expressions are designed to match everything in the following
+    // strings apart from the '[0]' index:
+    //
+    //    application[accreditations_attributes][0][accreditation]
+    //
+    var nameExpr = /([\w[\]]+)\[0\](\[\w+\])$/
+
+    var matches = name.match(nameExpr)
+    var newFieldName = matches[1] + '[' + newIndex + ']' + matches[2]
+
+    return newFieldName
+  }
+
+  DetailedExpandingListModule.prototype.buildFieldID = function buildFieldID (id, newIndex) {
+    // The following expressions are designed to match everything in the following
+    // strings apart from the '[0]' index:
+    //
+    //    application_accreditations_attributes_0_accreditation
+    //
+    var idExpr = /([\w[\]]+)_0_(\w+)$/
+
+    var matches = id.match(idExpr)
+    var newFieldID = matches[1] + '_' + newIndex + '_' + matches[2]
+
+    return newFieldID
+  }
+
+  DetailedExpandingListModule.prototype.getNewIndex = function getNewIndex () {
+    var $lastEl = this.$el.find('li:last-of-type')
+    var $hiddenInput = $lastEl.find('input[type=hidden]')
+
+    var indexExpr = /[\w[\]]+_(\d+)_\w+$/
+    var matches = $hiddenInput.attr('id').match(indexExpr)
+
+    var lastIndex = parseInt(matches[1])
+
+    return (lastIndex + 1)
+  }
+
+  DetailedExpandingListModule.prototype.hasInlineLabels = function hasInlineLabels () {
+    var classes = this.$el.attr('class')
+    var matches = classes.match(/with-inline-labels/)
+
+    if (matches !== null && matches.length >= 1) {
+      return true
+    } else {
+      return false
+    }
+  }
+
+  window.ProcurementHub.DetailedExpandingListModule = DetailedExpandingListModule
+}())
+
+$(function () {
+  $('*[data-module="detailed-expanding-list"]').each(function (i, element) {
+    // eslint-disable-next-line no-new
+    new window.ProcurementHub.DetailedExpandingListModule({
+      $el: $(element)
+    })
+  })
+})

--- a/app/concepts/sellers/seller_version/contract/recognition.rb
+++ b/app/concepts/sellers/seller_version/contract/recognition.rb
@@ -1,62 +1,64 @@
 module Sellers::SellerVersion::Contract
   class Recognition < Base
-    include Concerns::Contracts::Populators
-
-    AccreditationPopulator = -> (options) {
-      return NestedChildPopulator.call(options.merge(
-        params: [:accreditation],
-        model_klass: SellerAccreditation,
-        context: self,
-        foreign_key: :seller_id,
-      ))
-    }
-
-    AwardPopulator = -> (options) {
-      return NestedChildPopulator.call(options.merge(
-        params: [:award],
-        model_klass: SellerAward,
-        context: self,
-        foreign_key: :seller_id,
-      ))
-    }
-
-    EngagementPopulator = -> (options) {
-      return NestedChildPopulator.call(options.merge(
-        params: [:engagement],
-        model_klass: SellerEngagement,
-        context: self,
-        foreign_key: :seller_id,
-      ))
-    }
 
     AccreditationPrepopulator = ->(_) {
-      2.times do
-        self.accreditations << SellerAccreditation.new(seller_id: seller_id)
+      self.accreditations ||= []
+
+      count = 0
+      while (self.accreditations.size < 10 && count < 2)
+        self.accreditations << ''
+        count += 1
       end
     }
 
     AwardPrepopulator = ->(_) {
-      2.times do
-        self.awards << SellerAward.new(seller_id: seller_id)
+      self.awards ||= []
+
+      count = 0
+      while (self.awards.size < 10 && count < 2)
+        self.awards << ''
+        count += 1
       end
     }
 
     EngagementPrepopulator = ->(_) {
-      2.times do
-        self.engagements << SellerEngagement.new(seller_id: seller_id)
+      self.engagements ||= []
+
+      count = 0
+      while (self.engagements.size < 10 && count < 2)
+        self.engagements << ''
+        count += 1
       end
     }
 
-    collection :accreditations, on: :seller, prepopulator: AccreditationPrepopulator, populator: AccreditationPopulator do
-      property :accreditation
+    def accreditations=(array)
+      super(filter_blank_values(array))
     end
 
-    collection :awards, on: :seller, prepopulator: AwardPrepopulator, populator: AwardPopulator do
-      property :award
+    def awards=(array)
+      super(filter_blank_values(array))
     end
 
-    collection :engagements, on: :seller, prepopulator: EngagementPrepopulator, populator: EngagementPopulator do
-      property :engagement
+    def engagements=(array)
+      super(filter_blank_values(array))
+    end
+
+    def filter_blank_values(array)
+      Array(array).reject{|row|
+        row.gsub(/\s/,'').blank?
+      }
+    end
+
+    collection :accreditations, on: :seller_version, prepopulator: AccreditationPrepopulator
+    collection :awards, on: :seller_version, prepopulator: AwardPrepopulator
+    collection :engagements, on: :seller_version, prepopulator: EngagementPrepopulator
+
+    validation :default, inherit: true do
+      required(:seller_version).schema do
+        required(:accreditations).value(max_items?: 10)
+        required(:awards).value(max_items?: 10)
+        required(:engagements).value(max_items?: 10)
+      end
     end
   end
 end

--- a/app/inputs/text_field_array_input.rb
+++ b/app/inputs/text_field_array_input.rb
@@ -1,0 +1,26 @@
+class TextFieldArrayInput < SimpleForm::Inputs::StringInput
+  def input(wrapper_options = nil)
+    out = ActiveSupport::SafeBuffer.new
+
+    Array(object.public_send(attribute_name)).each_with_index do |element, index|
+      key = "#{attribute_name}_#{index}"
+
+      field = template.content_tag(:li) do
+        template.content_tag(:div, class: 'form-group') do
+          @builder.label(key, for: key, label: "#{index+1}.") +
+          @builder.text_field(attribute_name, input_html_options.merge(name: "#{@builder.object_name}[#{attribute_name}][]", value: element, id: key, class: 'form-control'))
+        end
+      end
+
+      out << field
+    end
+
+    template.content_tag(:ol) do
+      out
+    end
+  end
+
+  def input_type
+    :text
+  end
+end

--- a/app/models/concerns/seller_aliases.rb
+++ b/app/models/concerns/seller_aliases.rb
@@ -3,9 +3,6 @@ module Concerns::SellerAliases
 
   FIELDS = [
     :addresses,
-    :accreditations,
-    :engagements,
-    :awards,
   ]
 
   included do

--- a/app/models/seller.rb
+++ b/app/models/seller.rb
@@ -10,10 +10,7 @@ class Seller < ApplicationRecord
 
   has_one :waiting_seller
 
-  has_many :accreditations, class_name: 'SellerAccreditation', dependent: :destroy
   has_many :addresses, class_name: 'SellerAddress', dependent: :destroy
-  has_many :awards, class_name: 'SellerAward', dependent: :destroy
-  has_many :engagements, class_name: 'SellerEngagement', dependent: :destroy
   has_many :products
 
   has_many :versions, class_name: 'SellerVersion'

--- a/app/views/ops/seller_versions/_recognition_details.html.erb
+++ b/app/views/ops/seller_versions/_recognition_details.html.erb
@@ -5,7 +5,7 @@
       <% if seller.public_send(kind).any? %>
         <ul>
           <% seller.public_send(kind).each do |item| %>
-            <li><%= item.send(kind.to_s.singularize) %></li>
+            <li><%= item %></li>
           <% end %>
         </ul>
       <% else %>

--- a/app/views/sellers/applications/forms/_addresses.html.erb
+++ b/app/views/sellers/applications/forms/_addresses.html.erb
@@ -1,4 +1,4 @@
-<fieldset class="multiple-child-objects with-nested-blocks" data-module="expanding-list" data-object-name="address">
+<fieldset class="multiple-child-objects with-nested-blocks" data-module="detailed-expanding-list" data-object-name="address">
   <ol class="addresses">
   <%= f.simple_fields_for :addresses do |a| %>
     <li>

--- a/app/views/sellers/applications/forms/_recognition.html.erb
+++ b/app/views/sellers/applications/forms/_recognition.html.erb
@@ -1,43 +1,32 @@
 <p>This is your opportunity to share some of the things you are proud of. All questions are optional but can help your business attract potential buyers. If you're a start-up you can also list achievements from past roles or business ventures.</p>
 
-<fieldset class="multiple-child-objects with-inline-labels" data-module="expanding-list">
-  <legend class="with-label">Accreditations (optional)</legend>
-  <small class="form-text text-muted">Does your business have any formal accreditations you want to share?</small>
-
-  <ol>
-  <%= f.simple_fields_for :accreditations do |a| %>
-    <li>
-      <%= a.input :accreditation, label: "#{a.options[:child_index]+1}." %>
-      <%= a.hidden_field :id %>
-    </li>
-  <% end %>
-</ol>
-</fieldset>
-
-<fieldset class="multiple-child-objects with-inline-labels" data-module="expanding-list">
-  <legend class="with-label">Industry engagement (optional)</legend>
-  <small class="form-text text-muted">Are you involved in any boards, committees or groups for your industry?</small>
-
-  <ol>
-  <%= f.simple_fields_for :engagements do |a| %>
-    <li>
-      <%= a.input :engagement, label: "#{a.options[:child_index]+1}." %>
-      <%= a.hidden_field :id %>
-    </li>
-  <% end %>
-  </ol>
-</fieldset>
-
-<fieldset class="multiple-child-objects with-inline-labels" data-module="expanding-list">
-  <legend class="with-label">Awards (optional)</legend>
-  <small class="form-text text-muted">Has your work been recognised and awarded within your industry or by others?</small>
-
-  <ol>
-  <%= f.simple_fields_for :awards do |a| %>
-    <li>
-      <%= a.input :award, label: "#{a.options[:child_index]+1}." %>
-      <%= a.hidden_field :id %>
-    </li>
-  <% end %>
-  </ol>
-</fieldset>
+<%=
+  f.input :accreditations, as: :text_field_array,
+                           wrapper: :text_field_array,
+                           wrapper_html: {
+                             data: {
+                               module: 'expanding-list',
+                               expanding_list_max: 10,
+                             }
+                           }
+%>
+<%=
+  f.input :engagements, as: :text_field_array,
+                        wrapper: :text_field_array,
+                        wrapper_html: {
+                          data: {
+                            module: 'expanding-list',
+                            expanding_list_max: 10,
+                          }
+                        }
+%>
+<%=
+  f.input :awards,  as: :text_field_array,
+                    wrapper: :text_field_array,
+                    wrapper_html: {
+                      data: {
+                        module: 'expanding-list',
+                        expanding_list_max: 10,
+                      }
+                    }
+%>

--- a/app/views/sellers/applications/products/forms/shared/_expanding_list.html.erb
+++ b/app/views/sellers/applications/products/forms/shared/_expanding_list.html.erb
@@ -1,5 +1,5 @@
 <fieldset class="multiple-child-objects with-inline-labels"
-          data-module="expanding-list"
+          data-module="detailed-expanding-list"
           data-expanding-list-max="10"
           data-object-name="<%= field %>">
   <legend class="with-label"><%= t("#{i18n_base}.title") %></legend>

--- a/app/views/sellers/profiles/_company_details.html.erb
+++ b/app/views/sellers/profiles/_company_details.html.erb
@@ -32,7 +32,7 @@
   <dd>
     <ul>
       <% seller_version.accreditations.each do |item| %>
-        <li><%= item.accreditation %></li>
+        <li><%= item %></li>
       <% end %>
     </ul>
   </dd>
@@ -43,7 +43,7 @@
   <dd>
     <ul>
       <% seller_version.engagements.each do |item| %>
-        <li><%= item.engagement %></li>
+        <li><%= item %></li>
       <% end %>
     </ul>
   </dd>

--- a/app/views/sellers/profiles/_recognition.html.erb
+++ b/app/views/sellers/profiles/_recognition.html.erb
@@ -5,7 +5,7 @@
   <dd>
     <ul>
       <% seller_version.awards.each do |item| %>
-        <li><%= item.award %></li>
+        <li><%= item %></li>
       <% end %>
     </ul>
   </dd>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -190,4 +190,15 @@ SimpleForm.setup do |config|
     b.use :input, class: 'form-control', error_class: 'is-invalid'
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
   end
+
+  config.wrappers :text_field_array, tag: 'fieldset', class: 'multiple-child-objects with-inline-labels expanding-list', error_class: 'form-group-invalid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.wrapper :legend_tag, tag: 'legend', class: 'with-label' do |ba|
+      ba.use :label_text
+    end
+    b.use :accessible_hint, tag: 'small', class: 'form-text text-muted'
+    b.use :input, class: 'form-control', error_class: 'is-invalid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+  end
 end

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -414,14 +414,15 @@ SimpleForm.setup do |config|
   # Custom wrappers for input types. This should be a hash containing an input
   # type as key and the wrapper that will be used for all inputs with specified type.
   config.wrapper_mappings = {
-    boolean:       :vertical_boolean,
-    check_boxes:   :vertical_collection,
-    date:          :vertical_multi_select,
-    datetime:      :vertical_multi_select,
-    file:          :vertical_file,
-    radio_buttons: :vertical_collection,
-    range:         :vertical_range,
-    time:          :vertical_multi_select
+    boolean:          :vertical_boolean,
+    check_boxes:      :vertical_collection,
+    date:             :vertical_multi_select,
+    datetime:         :vertical_multi_select,
+    file:             :vertical_file,
+    radio_buttons:    :vertical_collection,
+    range:            :vertical_range,
+    time:             :vertical_multi_select,
+    text_field_array: :text_field_array,
   }
 
   # enable custom form wrappers

--- a/config/locales/sellers/en.yml
+++ b/config/locales/sellers/en.yml
@@ -260,6 +260,15 @@ en:
             label: 'Yes, with government outside Australia'
         recognition:
           short: 'List awards and accreditations'
+          accreditations:
+            label: Accreditations (optional)
+            hint: Does your business have any formal accreditations you want to share?
+          engagements:
+            label: Industry engagement (optional)
+            hint: Are you involved in any boards, committees or groups for your industry?
+          awards:
+            label: Awards (optional)
+            hint: Has your work been recognised and awarded within your industry or by others?
         products:
           short: 'Your cloud products (optional)'
         submit:

--- a/db/migrate/20180725020310_add_fields_for_seller_recognition.rb
+++ b/db/migrate/20180725020310_add_fields_for_seller_recognition.rb
@@ -1,0 +1,36 @@
+class AddFieldsForSellerRecognition < ActiveRecord::Migration[5.1]
+  def up
+    change_table :seller_versions do |t|
+      t.text :awards, array: true, default: []
+      t.text :accreditations, array: true, default: []
+      t.text :engagements, array: true, default: []
+    end
+
+    Seller.all.each do |seller|
+      awards = return_values_for('seller_awards', seller.id, 'award')
+      accreditations = return_values_for('seller_accreditations', seller.id, 'accreditation')
+      engagements = return_values_for('seller_engagements', seller.id, 'engagement')
+
+      seller.versions.each do |version|
+        version.update_attributes!(
+          awards: awards,
+          accreditations: accreditations,
+          engagements: engagements,
+        )
+      end
+    end
+  end
+
+  def down
+    remove_column :seller_versions, :awards
+    remove_column :seller_versions, :accreditations
+    remove_column :seller_versions, :engagements
+  end
+
+  def return_values_for(table, seller_id, key)
+    sql = "SELECT * FROM #{table} WHERE seller_id = '#{seller_id}'"
+    result = ActiveRecord::Base.connection.execute(sql)
+
+    result.each.map {|row| row[key] }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180718064601) do
+ActiveRecord::Schema.define(version: 20180725020310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -343,6 +343,9 @@ ActiveRecord::Schema.define(version: 20180718064601) do
     t.boolean "agree"
     t.datetime "agreed_at"
     t.integer "agreed_by_id"
+    t.text "awards", default: [], array: true
+    t.text "accreditations", default: [], array: true
+    t.text "engagements", default: [], array: true
   end
 
   create_table "sellers", force: :cascade do |t|

--- a/spec/concepts/sellers/seller_version/contract/recognition_spec.rb
+++ b/spec/concepts/sellers/seller_version/contract/recognition_spec.rb
@@ -8,122 +8,62 @@ RSpec.describe Sellers::SellerVersion::Contract::Recognition do
 
   let(:atts) {
     {
-      accreditations: [
-        { accreditation: 'Certified Test Case' },
-      ],
-      awards: [
-        { award: 'Test Case of the Year' },
-      ],
-      engagements: [
-        { engagement: 'Test Case Board Member' },
-      ],
+      accreditations: [ 'Certified Test Case' ],
+      awards: [ 'Test Case of the Year' ],
+      engagements: [ 'Test Case Board Member' ],
     }
   }
 
-  it 'can save and create nested objects with valid attributes' do
+  it 'can save accreditations' do
     subject.validate(atts)
 
     expect(subject).to be_valid
     expect(subject.save).to eq(true)
-    seller.reload
 
-    expect(seller.accreditations.count).to eq(1)
-    expect(seller.awards.count).to eq(1)
-    expect(seller.engagements.count).to eq(1)
+    version.reload
+
+    expect(version.accreditations.count).to eq(1)
+    expect(version.awards.count).to eq(1)
+    expect(version.engagements.count).to eq(1)
   end
 
-  it 'ignores any nested children where text is blank' do
+  it 'ignores blank accreditations' do
     subject.validate(atts.merge(
-      accreditations: [
-        { accreditation: 'Item 1' },
-        { accreditation: '' },
-        { accreditation: 'Item 3' },
-      ]
+      accreditations: ['Item 1', '', 'Item 3']
     ))
     subject.save
 
-    expect(seller.accreditations.count).to eq(2)
-    expect(seller.accreditations.map(&:accreditation)).to contain_exactly(
+    version.reload
+
+    expect(version.accreditations.count).to eq(2)
+    expect(version.accreditations).to contain_exactly(
       'Item 1', 'Item 3'
     )
   end
 
-  it 'updates a nested child given an ID' do
-    existing = create(:seller_accreditation, seller: seller, accreditation: 'Existing')
+  it 'updates an accreditation' do
+    version.update_attribute(:accreditations, [ 'Existing' ])
 
     subject.validate(atts.merge(
-      accreditations: [
-        { id: existing.id, accreditation: 'Updated' },
-      ]
+      accreditations: ['Updated']
     ))
-    subject.save
-    existing.reload
 
-    expect(existing.accreditation).to eq('Updated')
+    subject.save
+    version.reload
+
+    expect(version.accreditations).to contain_exactly('Updated')
   end
 
-  it 'destroys a nested child given an ID and a blank value' do
-    existing = create(:seller_accreditation, seller: seller, accreditation: 'Existing')
+  it 'removes an accreditation given a blank value' do
+    version.update_attribute(:accreditations, [ 'Existing' ])
 
     subject.validate(atts.merge(
-      accreditations: [
-        { id: existing.id, accreditation: '' },
-      ]
+      accreditations: ['']
     ))
+
     subject.save
-    seller.reload
+    version.reload
 
-    expect(seller.accreditations.count).to eq(0)
-  end
-
-  context 'with _attributes keys' do
-    it 'can create nested children' do
-      atts = {
-        "accreditations_attributes" => {
-          "0" => { accreditation: 'Certified Test Case' },
-        },
-        "awards_attributes" => {
-          "0" => { award: 'Test Case of the Year' },
-        },
-        "engagements_attributes" => {
-          "0" => { engagement: 'Test Case Board Member' },
-        },
-      }
-      subject.validate(atts)
-      subject.save
-      seller.reload
-
-      expect(seller.accreditations.count).to eq(1)
-      expect(seller.awards.count).to eq(1)
-      expect(seller.engagements.count).to eq(1)
-    end
-
-    it 'can update nested children' do
-      existing = create(:seller_accreditation, seller: seller, accreditation: 'Existing')
-
-      subject.validate({
-        "accreditations_attributes" => {
-          "0" => { id: existing.id, accreditation: 'Updated' },
-        }
-      })
-      subject.save
-      existing.reload
-
-      expect(existing.accreditation).to eq('Updated')
-    end
-
-    it 'can destroy nested children given a blank string' do
-      existing = create(:seller_accreditation, seller: seller, accreditation: 'Existing')
-
-      subject.validate({
-        "accreditations_attributes" => {
-          "0" => { id: existing.id, accreditation: '' },
-        }
-      })
-      subject.save
-      seller.reload
-
-      expect(seller.accreditations.count).to eq(0)
-    end
+    expect(version.accreditations.count).to eq(0)
   end
 end

--- a/spec/factories/seller_versions.rb
+++ b/spec/factories/seller_versions.rb
@@ -38,6 +38,16 @@ FactoryBot.define do
       representative_email 'signy@example.org'
       representative_phone '02 9765 4321'
 
+      sequence(:accreditations) {|n|
+        [ "ISO#{27000+n} compliance" ]
+      }
+      engagements [
+        "Board member, Australian Bakers' Association"
+      ]
+      sequence(:awards) {|n|
+        [ "Baker of the year #{2010+n}" ]
+      }
+
       agree true
     end
 

--- a/spec/factories/sellers.rb
+++ b/spec/factories/sellers.rb
@@ -30,29 +30,8 @@ FactoryBot.define do
       end
     end
 
-    trait :with_award do
-      after(:create) do |seller|
-        create(:seller_award, seller: seller)
-      end
-    end
-
-    trait :with_engagement do
-      after(:create) do |seller|
-        create(:seller_engagement, seller: seller)
-      end
-    end
-
-    trait :with_accreditation do
-      after(:create) do |seller|
-        create(:seller_accreditation, seller: seller)
-      end
-    end
-
     trait :with_full_profile do
-      with_accreditation
       with_address
-      with_award
-      with_engagement
     end
 
     factory :active_seller, traits: [:active, :with_full_profile]

--- a/spec/features/ops_seller_review_spec.rb
+++ b/spec/features/ops_seller_review_spec.rb
@@ -132,23 +132,19 @@ RSpec.describe 'Reviewing seller applications', type: :feature, js: true do
     it 'shows seller recognition details' do
       application = create(:awaiting_assignment_seller_version)
 
-      accreditation = create(:seller_accreditation, seller: application.seller)
-      engagement = create(:seller_engagement, seller: application.seller)
-      award = create(:seller_award, seller: application.seller)
-
       visit ops_seller_application_path(application)
       click_navigation_item 'Seller details'
 
       within_definition ops_field_label(:accreditations) do
-        expect(page).to have_content(accreditation.accreditation)
+        expect(page).to have_content(application.accreditations.first)
       end
 
       within_definition ops_field_label(:engagements) do
-        expect(page).to have_content(engagement.engagement)
+        expect(page).to have_content(application.engagements.first)
       end
 
       within_definition ops_field_label(:awards) do
-        expect(page).to have_content(award.award)
+        expect(page).to have_content(application.awards.first)
       end
     end
   end

--- a/spec/features/seller_profile_spec.rb
+++ b/spec/features/seller_profile_spec.rb
@@ -87,12 +87,12 @@ RSpec.describe 'Seller profiles', type: :feature, js: true, skip_login: true do
           seller.addresses.first.state_text,
           seller.addresses.first.postcode
         )
-        expect_list_entry('Accreditations', seller.accreditations.first.accreditation)
-        expect_list_entry('Industry engagement', seller.engagements.first.engagement)
+        expect_list_entry('Accreditations', version.accreditations.first)
+        expect_list_entry('Industry engagement', version.engagements.first)
       end
 
       within '#recognition' do
-        expect_list_entry('Awards', seller.awards.first.award)
+        expect_list_entry('Awards', version.awards.first)
       end
     end
   end


### PR DESCRIPTION
This moves seller awards, accreditations and engagements from `Seller` to `SellerVersion`.

It simplifies their storage by using a PostgreSQL array column on the `seller_versions` table, instead of separate database tables and associations.

The database migration takes existing seller awards, accreditations and engagements, and stores a copy of them on each seller version which exists.

Once these changes have been deployed to production, a subsequent pull request will remove the old models and database tables from the application.