### PR TITLE
Drop old seller relation tables

### DIFF
--- a/app/concepts/sellers/seller_version/contract/addresses.rb
+++ b/app/concepts/sellers/seller_version/contract/addresses.rb
@@ -5,7 +5,7 @@ module Sellers::SellerVersion::Contract
 
     AddressPrepopulator = ->(_) {
       if self.addresses.size < 1
-        self.addresses << OpenStruct.new(country: 'AU')
+        self.addresses << SellerAddress.new(country: 'AU')
       end
     }
 
@@ -23,7 +23,7 @@ module Sellers::SellerVersion::Contract
 
       return skip! if fragment['_delete'] == '1'
 
-      address = OpenStruct.new(
+      address = SellerAddress.new(
         fragment.slice('address', 'suburb', 'state', 'postcode', 'country')
       )
 

--- a/app/decorators/seller_address_decorator.rb
+++ b/app/decorators/seller_address_decorator.rb
@@ -5,7 +5,7 @@ class SellerAddressDecorator < BaseDecorator
   end
 
   def state
-    SellerAddress.state.find_value(super)&.text
+    state_text
   end
 
 end

--- a/app/models/seller_accreditation.rb
+++ b/app/models/seller_accreditation.rb
@@ -1,3 +1,0 @@
-class SellerAccreditation < ApplicationRecord
-  belongs_to :seller
-end

--- a/app/models/seller_address.rb
+++ b/app/models/seller_address.rb
@@ -1,7 +1,42 @@
-class SellerAddress < ApplicationRecord
+class SellerAddress < OpenStruct
+  # NOTE: This object represents a seller address, which is persisted as an
+  # array of JSON objects on the SellerVersion model.
+  #
+  # This object remains useful for serialization, enumerizing the `state`
+  # field, and building forms for addresses.
+  #
+  extend ActiveModel::Naming
   extend Enumerize
+  extend Forwardable
 
-  belongs_to :seller
+  FIELDS = [:address, :suburb, :postcode, :country]
 
   enumerize :state, in: [ :nsw, :act, :nt, :qld, :sa, :tas, :vic, :wa, :outside_au ]
+
+  def initialize(attributes={})
+    attributes.symbolize_keys! if attributes.is_a?(Hash)
+
+    # NOTE: As we have defined the `state` field in enumerize, we need to
+    # directly set the value of the field as it does not infer it from the
+    # OpenStruct table
+    #
+    self.state = attributes[:state]
+
+    super(attributes.slice(*FIELDS))
+  end
+
+  def to_h
+    super.merge(state: state)
+  end
+
+  # NOTE: The following methods serve no purpose but to maintain compatibility
+  # with building form objects.
+  #
+  def id
+    nil
+  end
+
+  def persisted?
+    true
+  end
 end

--- a/app/models/seller_award.rb
+++ b/app/models/seller_award.rb
@@ -1,3 +1,0 @@
-class SellerAward < ApplicationRecord
-  belongs_to :seller
-end

--- a/app/models/seller_engagement.rb
+++ b/app/models/seller_engagement.rb
@@ -1,3 +1,0 @@
-class SellerEngagement < ApplicationRecord
-  belongs_to :seller
-end

--- a/app/models/seller_version.rb
+++ b/app/models/seller_version.rb
@@ -73,7 +73,7 @@ class SellerVersion < ApplicationRecord
 
   def addresses
     Array(self[:addresses]).map {|value|
-      OpenStruct.new(value)
+      SellerAddress.new(value)
     }
   end
 

--- a/db/migrate/20180802010027_drop_old_seller_relation_tables.rb
+++ b/db/migrate/20180802010027_drop_old_seller_relation_tables.rb
@@ -1,0 +1,50 @@
+class DropOldSellerRelationTables < ActiveRecord::Migration[5.1]
+  def up
+    remove_foreign_key :seller_accreditations, :sellers
+    remove_foreign_key :seller_awards, :sellers
+    remove_foreign_key :seller_engagements, :sellers
+    
+    drop_table :seller_accreditations
+    drop_table :seller_addresses
+    drop_table :seller_awards
+    drop_table :seller_engagements
+  end
+
+  def down
+    create_table :seller_accreditations do |t|
+      t.integer :seller_id, null: false
+      t.string :accreditation
+
+      t.timestamps
+    end
+
+    create_table :seller_addresses do |t|
+      t.integer :seller_id, null: false
+      t.string :address
+      t.string :suburb
+      t.string :state
+      t.string :postcode
+      t.string :country
+
+      t.timestamps
+    end
+
+    create_table :seller_awards do |t|
+      t.integer :seller_id, null: false
+      t.string :award
+
+      t.timestamps
+    end
+
+    create_table :seller_engagements do |t|
+      t.integer :seller_id, null: false
+      t.string :engagement
+
+      t.timestamps
+    end
+
+    add_foreign_key :seller_accreditations, :sellers
+    add_foreign_key :seller_awards, :sellers
+    add_foreign_key :seller_engagements, :sellers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180731034736) do
+ActiveRecord::Schema.define(version: 20180802010027) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -253,38 +253,6 @@ ActiveRecord::Schema.define(version: 20180731034736) do
     t.text "data_disposal_approach"
   end
 
-  create_table "seller_accreditations", force: :cascade do |t|
-    t.integer "seller_id", null: false
-    t.string "accreditation"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "seller_addresses", force: :cascade do |t|
-    t.integer "seller_id", null: false
-    t.string "address"
-    t.string "suburb"
-    t.string "state"
-    t.string "postcode"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "country"
-  end
-
-  create_table "seller_awards", force: :cascade do |t|
-    t.integer "seller_id", null: false
-    t.string "award"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "seller_engagements", force: :cascade do |t|
-    t.integer "seller_id", null: false
-    t.string "engagement"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "seller_versions", force: :cascade do |t|
     t.string "state", null: false
     t.text "response"
@@ -400,8 +368,5 @@ ActiveRecord::Schema.define(version: 20180731034736) do
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "seller_accreditations", "sellers"
-  add_foreign_key "seller_awards", "sellers"
-  add_foreign_key "seller_engagements", "sellers"
   add_foreign_key "seller_versions", "sellers"
 end

--- a/spec/factories/seller_accreditations.rb
+++ b/spec/factories/seller_accreditations.rb
@@ -1,6 +1,0 @@
-FactoryBot.define do
-  factory :seller_accreditation do
-    sequence(:accreditation) {|n| "ISO#{27000+n} compliance" }
-    seller
-  end
-end

--- a/spec/factories/seller_addresses.rb
+++ b/spec/factories/seller_addresses.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :seller_address do
-    association :seller
-    
     address '123 Test Street'
     suburb 'Sydney'
     state 'nsw'
     postcode '2000'
     country 'AU'
+
+    initialize_with { new(attributes) }
   end
 end

--- a/spec/factories/seller_awards.rb
+++ b/spec/factories/seller_awards.rb
@@ -1,6 +1,0 @@
-FactoryBot.define do
-  factory :seller_award do
-    sequence(:award) {|n| "Baker of the year #{2010+n}" }
-    seller
-  end
-end

--- a/spec/factories/seller_engagements.rb
+++ b/spec/factories/seller_engagements.rb
@@ -1,6 +1,0 @@
-FactoryBot.define do
-  factory :seller_engagement do
-    engagement "Board member, Australian Bakers' Association"
-    seller
-  end
-end

--- a/spec/models/seller_address_spec.rb
+++ b/spec/models/seller_address_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe SellerAddress do
+  let(:attributes) { attributes_for(:seller_address) }
+
+  subject { described_class.new(attributes) }
+
+  describe '#initialize' do
+    it 'can be initialized with attributes' do
+      expect(subject.address).to eq(attributes[:address])
+      expect(subject.suburb).to eq(attributes[:suburb])
+      expect(subject.state).to eq(attributes[:state])
+      expect(subject.postcode).to eq(attributes[:postcode])
+      expect(subject.country).to eq(attributes[:country])
+    end
+  end
+
+  describe "#to_h" do
+    it 'includes the `state` field' do
+      expect(subject.to_h[:state]).to eq(attributes[:state])
+    end
+  end
+
+  describe 'ActiveModel behaviour' do
+    it 'responds to #persisted?' do
+      expect(subject).to respond_to(:persisted?)
+    end
+
+    it 'responds to #id' do
+      expect(subject).to respond_to(:id)
+    end
+  end
+end


### PR DESCRIPTION
Now that all seller data (excluding documents) has been migrated to the `seller_versions` table (in #300 and #303), this goes ahead and cleans up the old data and models.

This:
- drops the `seller_awards`, `seller_accreditations`, `seller_engagements` and `seller_addresses` tables from the database
- removes the `SellerAward`, `SellerAccreditation` and `SellerEngagement` models
- converts the `SellerAddress` model into a simple value object, useful for serialization and building the address forms