### PR TITLE
Migrate documents to seller versions

### DIFF
--- a/app/concepts/sellers/seller_version/contract/base.rb
+++ b/app/concepts/sellers/seller_version/contract/base.rb
@@ -7,7 +7,7 @@ module Sellers::SellerVersion::Contract
     include Forms::ValidationHelper
 
     def upload_for(key)
-      self.model[:seller].public_send(key)
+      self.model[:seller_version].public_send(key)
     end
 
     def i18n_base

--- a/app/concepts/sellers/seller_version/contract/financial_statement.rb
+++ b/app/concepts/sellers/seller_version/contract/financial_statement.rb
@@ -3,16 +3,13 @@ module Sellers::SellerVersion::Contract
     feature Reform::Form::ActiveModel::FormBuilderMethods
     feature Reform::Form::MultiParameterAttributes
 
-    property :financial_statement_file,   on: :seller
+    property :financial_statement_file,   on: :seller_version
     property :financial_statement_expiry, on: :seller_version, multi_params: true
-    property :remove_financial_statement, on: :seller
+    property :remove_financial_statement, on: :seller_version
 
     validation :default, inherit: true do
-      required(:seller).schema do
-        required(:financial_statement_file).filled(:file?)
-      end
-
       required(:seller_version).schema do
+        required(:financial_statement_file).filled(:file?)
         required(:financial_statement_expiry).filled(:date?)
       end
     end

--- a/app/concepts/sellers/seller_version/contract/product_liability.rb
+++ b/app/concepts/sellers/seller_version/contract/product_liability.rb
@@ -3,9 +3,9 @@ module Sellers::SellerVersion::Contract
     feature Reform::Form::ActiveModel::FormBuilderMethods
     feature Reform::Form::MultiParameterAttributes
 
-    property :product_liability_certificate_file,   on: :seller
+    property :product_liability_certificate_file,   on: :seller_version
     property :product_liability_certificate_expiry, on: :seller_version, multi_params: true
-    property :remove_product_liability_certificate, on: :seller
+    property :remove_product_liability_certificate, on: :seller_version
 
     module Types
       include Dry::Types.module
@@ -39,20 +39,17 @@ module Sellers::SellerVersion::Contract
         end
       end
 
-      required(:seller).schema do
-        required(:product_liability_certificate_file, Types::File).maybe(:file_uploaded?)
-      end
-
       required(:seller_version).schema do
+        required(:product_liability_certificate_file, Types::File).maybe(:file_uploaded?)
         required(:product_liability_certificate_expiry, Types::Date).maybe(:date?, :in_future?)
-      end
 
-      rule(product_liability_certificate_file: [[:seller, :product_liability_certificate_file], [:seller_version, :product_liability_certificate_expiry]]) do |file, expiry|
-        expiry.filled?.then(file.filled?)
-      end
+        rule(product_liability_certificate_file: [:product_liability_certificate_file, :product_liability_certificate_expiry]) do |file, expiry|
+          expiry.filled?.then(file.filled?)
+        end
 
-      rule(product_liability_certificate_expiry: [[:seller, :product_liability_certificate_file], [:seller_version, :product_liability_certificate_expiry]]) do |file, expiry|
-        file.filled?.then(expiry.filled?)
+        rule(product_liability_certificate_expiry: [:product_liability_certificate_file, :product_liability_certificate_expiry]) do |file, expiry|
+          file.filled?.then(expiry.filled?)
+        end
       end
     end
 

--- a/app/concepts/sellers/seller_version/contract/professional_indemnity.rb
+++ b/app/concepts/sellers/seller_version/contract/professional_indemnity.rb
@@ -3,16 +3,13 @@ module Sellers::SellerVersion::Contract
     feature Reform::Form::ActiveModel::FormBuilderMethods
     feature Reform::Form::MultiParameterAttributes
 
-    property :professional_indemnity_certificate_file,   on: :seller
+    property :professional_indemnity_certificate_file,   on: :seller_version
     property :professional_indemnity_certificate_expiry, on: :seller_version, multi_params: true
-    property :remove_professional_indemnity_certificate, on: :seller
+    property :remove_professional_indemnity_certificate, on: :seller_version
 
     validation :default, inherit: true do
-      required(:seller).schema do
-        required(:professional_indemnity_certificate_file).filled(:file?)
-      end
-
       required(:seller_version).schema do
+        required(:professional_indemnity_certificate_file).filled(:file?)
         required(:professional_indemnity_certificate_expiry).filled(:date?, :in_future?)
       end
     end

--- a/app/concepts/sellers/seller_version/contract/workers_compensation.rb
+++ b/app/concepts/sellers/seller_version/contract/workers_compensation.rb
@@ -3,10 +3,10 @@ module Sellers::SellerVersion::Contract
     feature Reform::Form::ActiveModel::FormBuilderMethods
     feature Reform::Form::MultiParameterAttributes
 
-    property :workers_compensation_certificate_file,   on: :seller
+    property :workers_compensation_certificate_file,   on: :seller_version
     property :workers_compensation_certificate_expiry, on: :seller_version, multi_params: true
     property :workers_compensation_exempt,             on: :seller_version
-    property :remove_workers_compensation_certificate, on: :seller
+    property :remove_workers_compensation_certificate, on: :seller_version
 
     # NOTE: Trying to implement conditional validation on this model has been
     # painstaking, but the following does work.
@@ -89,17 +89,15 @@ module Sellers::SellerVersion::Contract
         required(:workers_compensation_exempt, Types::Bool).filled
         required(:workers_compensation_certificate_expiry, Types::Date).maybe(:date?, :in_future?)
 
+        required(:workers_compensation_certificate_file, Types::File).maybe(:file_uploaded?)
+
         rule(workers_compensation_certificate_expiry: [:workers_compensation_exempt, :workers_compensation_certificate_expiry]) do |exempt, expiry|
           (exempt.false? | exempt.eql?('0')).then(expiry.filled?)
         end
-      end
 
-      required(:seller).schema do
-        required(:workers_compensation_certificate_file, Types::File).maybe(:file_uploaded?)
-      end
-
-      rule(workers_compensation_certificate_file: [[:seller_version, :workers_compensation_exempt], [:seller, :workers_compensation_certificate_file]]) do |exempt, document|
-        (exempt.false? | exempt.eql?('0')).then(document.filled?)
+        rule(workers_compensation_certificate_file: [:workers_compensation_exempt, :workers_compensation_certificate_file]) do |exempt, document|
+          (exempt.false? | exempt.eql?('0')).then(document.filled?)
+        end
       end
     end
   end

--- a/app/concepts/sellers/seller_version/products/operation/clone.rb
+++ b/app/concepts/sellers/seller_version/products/operation/clone.rb
@@ -5,7 +5,6 @@ class Sellers::SellerVersion::Products::Clone < Trailblazer::Operation
   step :set_new_product_name!
   step :persist_new_product!
   step :copy_features_and_benefits!
-  step :copy_documents!
 
   def model!(options, params:, **)
     return false unless options['config.current_user'].present?
@@ -42,15 +41,6 @@ class Sellers::SellerVersion::Products::Clone < Trailblazer::Operation
     options[:product_model].benefits.each do |record|
       options[:new_product_model].benefits.create!(
         benefit: record.benefit,
-      )
-    end
-  end
-
-  def copy_documents!(options, **)
-    options[:product_model].documents.each do |document|
-      options[:new_product_model].documents.create!(
-        kind: document.kind,
-        document: document.document,
       )
     end
   end

--- a/app/jobs/document_scan_job.rb
+++ b/app/jobs/document_scan_job.rb
@@ -4,13 +4,11 @@ class DocumentScanJob < ApplicationJob
   def perform(document)
     file = download_file(document)
     status = case Clamby.safe?(file)
-              when true then 'clean'
-              when false then 'infected'
+              when true then document.mark_as_clean!
+              when false then document.mark_as_infected!
               else
                 raise ScanFailure
               end
-
-    document.update_attribute(:scan_status, status)
   end
 
 private

--- a/app/models/seller.rb
+++ b/app/models/seller.rb
@@ -14,10 +14,6 @@ class Seller < ApplicationRecord
   has_many :versions, class_name: 'SellerVersion'
   has_one :approved_version, ->{ approved }, class_name: 'SellerVersion'
 
-  has_documents :financial_statement, :professional_indemnity_certificate,
-                :workers_compensation_certificate,
-                :product_liability_certificate
-
   aasm column: :state do
     state :inactive, initial: true
     state :active

--- a/app/models/seller_version.rb
+++ b/app/models/seller_version.rb
@@ -3,6 +3,7 @@ class SellerVersion < ApplicationRecord
   extend Enumerize
 
   include Concerns::StateScopes
+  include Concerns::Documentable
 
   before_save :normalise_abn
 
@@ -12,6 +13,10 @@ class SellerVersion < ApplicationRecord
 
   has_many :events, -> { order(created_at: :desc) }, as: :eventable, class_name: 'Event::Event'
   has_many :owners, through: :seller, class_name: 'User'
+
+  has_documents :financial_statement, :professional_indemnity_certificate,
+                :workers_compensation_certificate,
+                :product_liability_certificate
 
   aasm column: :state do
     state :created, initial: true

--- a/app/views/admin/seller_versions/_document.html.erb
+++ b/app/views/admin/seller_versions/_document.html.erb
@@ -20,7 +20,7 @@
         </p>
       <% end %>
 
-      <% if (upload = application.seller.send(key)) && upload.document.present? %>
+      <% if (upload = application.send(key)) && upload.document.present? %>
         <p class="file-name"><%= upload.original_filename %></p>
 
         <% if file_clean?(upload) %>

--- a/db/migrate/20180802063348_migrate_seller_documents_to_versions.rb
+++ b/db/migrate/20180802063348_migrate_seller_documents_to_versions.rb
@@ -1,0 +1,42 @@
+class MigrateSellerDocumentsToVersions < ActiveRecord::Migration[5.1]
+  def up
+    add_column :seller_versions, :financial_statement_id, :integer
+    add_column :seller_versions, :professional_indemnity_certificate_id, :integer
+    add_column :seller_versions, :workers_compensation_certificate_id, :integer
+    add_column :seller_versions, :product_liability_certificate_id, :integer
+
+    all_documents.each do |document|
+      kind = document['kind']
+      seller = Seller.find(document['documentable_id'])
+
+      seller.versions.update_all({
+        "#{kind}_id" => document['id']
+      })
+
+      puts "Doc ##{document['id']} => seller versions update: #{seller.versions.map(&:id).join(', ')}"
+    end
+
+    add_foreign_key :seller_versions, :documents, column: :financial_statement_id
+    add_foreign_key :seller_versions, :documents, column: :professional_indemnity_certificate_id
+    add_foreign_key :seller_versions, :documents, column: :workers_compensation_certificate_id
+    add_foreign_key :seller_versions, :documents, column: :product_liability_certificate_id
+  end
+
+  def down
+    remove_foreign_key :seller_versions, column: :financial_statement_id
+    remove_foreign_key :seller_versions, column: :professional_indemnity_certificate_id
+    remove_foreign_key :seller_versions, column: :workers_compensation_certificate_id
+    remove_foreign_key :seller_versions, column: :product_liability_certificate_id
+
+    remove_column :seller_versions, :financial_statement_id
+    remove_column :seller_versions, :professional_indemnity_certificate_id
+    remove_column :seller_versions, :workers_compensation_certificate_id
+    remove_column :seller_versions, :product_liability_certificate_id
+  end
+
+  def all_documents
+    sql = "SELECT * FROM documents WHERE documentable_type='Seller' AND
+      kind IN ('financial_statement', 'professional_indemnity_certificate', 'workers_compensation_certificate', 'product_liability_certificate')"
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end

--- a/db/migrate/20180803043326_migrate_product_term_documents.rb
+++ b/db/migrate/20180803043326_migrate_product_term_documents.rb
@@ -1,0 +1,24 @@
+class MigrateProductTermDocuments < ActiveRecord::Migration[5.1]
+  def up
+    add_column :products, :terms_id, :integer
+
+    all_documents.each do |document|
+      product = Product.find(document['documentable_id'])
+      product.update_attribute(:terms_id, document['id'])
+
+      puts "Doc ##{document['id']} => product update: #{product.id}"
+    end
+
+    add_foreign_key :products, :documents, column: :terms_id
+  end
+
+  def down
+    remove_foreign_key :products, column: :terms_id
+    remove_column :products, :terms_id
+  end
+
+  def all_documents
+    sql = "SELECT * FROM documents WHERE documentable_type='Product' AND kind IN ('terms')"
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180802010027) do
+ActiveRecord::Schema.define(version: 20180802063348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -315,6 +315,10 @@ ActiveRecord::Schema.define(version: 20180802010027) do
     t.text "accreditations", default: [], array: true
     t.text "engagements", default: [], array: true
     t.jsonb "addresses", default: []
+    t.integer "financial_statement_id"
+    t.integer "professional_indemnity_certificate_id"
+    t.integer "workers_compensation_certificate_id"
+    t.integer "product_liability_certificate_id"
   end
 
   create_table "sellers", force: :cascade do |t|
@@ -368,5 +372,9 @@ ActiveRecord::Schema.define(version: 20180802010027) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "seller_versions", "documents", column: "financial_statement_id"
+  add_foreign_key "seller_versions", "documents", column: "product_liability_certificate_id"
+  add_foreign_key "seller_versions", "documents", column: "professional_indemnity_certificate_id"
+  add_foreign_key "seller_versions", "documents", column: "workers_compensation_certificate_id"
   add_foreign_key "seller_versions", "sellers"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180802063348) do
+ActiveRecord::Schema.define(version: 20180803043326) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -251,6 +251,7 @@ ActiveRecord::Schema.define(version: 20180802063348) do
     t.string "access_control_testing_frequency"
     t.text "deployment_model", default: [], array: true
     t.text "data_disposal_approach"
+    t.integer "terms_id"
   end
 
   create_table "seller_versions", force: :cascade do |t|
@@ -372,6 +373,7 @@ ActiveRecord::Schema.define(version: 20180802063348) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "products", "documents", column: "terms_id"
   add_foreign_key "seller_versions", "documents", column: "financial_statement_id"
   add_foreign_key "seller_versions", "documents", column: "product_liability_certificate_id"
   add_foreign_key "seller_versions", "documents", column: "professional_indemnity_certificate_id"

--- a/spec/concepts/sellers/seller_version/products/operation/clone_spec.rb
+++ b/spec/concepts/sellers/seller_version/products/operation/clone_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Sellers::SellerVersion::Products::Clone do
     expect(new_product.benefits.count).to eq(benefits.count)
   end
 
-  it 'copies documents' do
+  it 'copies the terms document' do
     product.terms_file = Rack::Test::UploadedFile.new(
       Rails.root.join('spec', 'fixtures', 'files', 'example.pdf'),
       'application/pdf'
@@ -86,8 +86,7 @@ RSpec.describe Sellers::SellerVersion::Products::Clone do
     result = perform_operation
     new_product = result[:new_product_model]
 
-    expect(new_product.documents.count).to eq(product.documents.count)
-    expect(new_product.documents.first.kind).to eq(product.documents.first.kind)
+    expect(new_product.terms_id).to eq(product.terms_id)
   end
 
   describe 'finding the product' do

--- a/spec/decorators/product_decorator_spec.rb
+++ b/spec/decorators/product_decorator_spec.rb
@@ -14,16 +14,6 @@ RSpec.describe ProductDecorator do
       end
     end
 
-    context 'when a document with no attached file is present' do
-      before(:each) {
-        product.terms = create(:clean_document, documentable: product, kind: 'terms', document: nil)
-      }
-
-      it 'returns false' do
-        expect(subject.display_additional_terms?).to be_falsey
-      end
-    end
-
     context 'when a clean document is present' do
       before(:each) {
         product.terms = create(:clean_document, documentable: product, kind: 'terms')

--- a/spec/decorators/product_decorator_spec.rb
+++ b/spec/decorators/product_decorator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ProductDecorator do
 
     context 'when a document with no attached file is present' do
       before(:each) {
-        create(:clean_document, documentable: product, kind: 'terms', document: nil)
+        product.terms = create(:clean_document, documentable: product, kind: 'terms', document: nil)
       }
 
       it 'returns false' do
@@ -26,7 +26,7 @@ RSpec.describe ProductDecorator do
 
     context 'when a clean document is present' do
       before(:each) {
-        create(:clean_document, documentable: product, kind: 'terms')
+        product.terms = create(:clean_document, documentable: product, kind: 'terms')
       }
 
       it 'returns true' do
@@ -36,7 +36,7 @@ RSpec.describe ProductDecorator do
 
     context 'when an unscanned document is present' do
       before(:each) {
-        create(:unscanned_document, documentable: product, kind: 'terms')
+        product.terms = create(:unscanned_document, documentable: product, kind: 'terms')
       }
 
       it 'returns false' do
@@ -46,7 +46,7 @@ RSpec.describe ProductDecorator do
 
     context 'when an infected document is present' do
       before(:each) {
-        create(:infected_document, documentable: product, kind: 'terms')
+        product.terms = create(:infected_document, documentable: product, kind: 'terms')
       }
 
       it 'returns false' do

--- a/spec/features/admin_seller_review_spec.rb
+++ b/spec/features/admin_seller_review_spec.rb
@@ -30,11 +30,18 @@ RSpec.describe 'Reviewing seller applications', type: :feature, js: true do
     end
 
     it 'can see uploaded documents' do
-      application = create(:awaiting_assignment_seller_version)
+      seller = create(:inactive_seller)
 
-      create(:clean_document, documentable: application.seller, kind: 'financial_statement')
-      create(:unscanned_document, documentable: application.seller, kind: 'professional_indemnity_certificate')
-      create(:infected_document, documentable: application.seller, kind: 'workers_compensation_certificate')
+      fs = create(:clean_document, documentable: seller, kind: 'financial_statement')
+      pic = create(:unscanned_document, documentable: seller, kind: 'professional_indemnity_certificate')
+      wcc = create(:infected_document, documentable: seller, kind: 'workers_compensation_certificate')
+
+      application = create(:awaiting_assignment_seller_version,
+        seller: seller,
+        financial_statement_id: fs.id,
+        professional_indemnity_certificate_id: pic.id,
+        workers_compensation_certificate_id: wcc.id,
+      )
 
       visit '/ops'
       click_on 'Seller applications'
@@ -84,6 +91,8 @@ RSpec.describe 'Reviewing seller applications', type: :feature, js: true do
         let!(:document) { create(:unscanned_document, documentable: product, kind: 'terms') }
 
         before(:example) {
+          product.update_attribute(:terms_id, document.id)
+
           visit admin_seller_application_path(application)
           click_navigation_item(product.name)
         }
@@ -100,6 +109,8 @@ RSpec.describe 'Reviewing seller applications', type: :feature, js: true do
         let!(:document) { create(:clean_document, documentable: product, kind: 'terms') }
 
         before(:example) {
+          product.update_attribute(:terms_id, document.id)
+
           visit admin_seller_application_path(application)
           click_navigation_item(product.name)
         }
@@ -116,6 +127,8 @@ RSpec.describe 'Reviewing seller applications', type: :feature, js: true do
         let!(:document) { create(:infected_document, documentable: product, kind: 'terms') }
 
         before(:example) {
+          product.update_attribute(:terms_id, document.id)
+          
           visit admin_seller_application_path(application)
           click_navigation_item(product.name)
         }

--- a/spec/features/product_profile_spec.rb
+++ b/spec/features/product_profile_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe 'Showing products', type: :feature, js: true do
 
   it 'links to the additional terms' do
     document = create(:clean_document, documentable: product, kind: 'terms')
+    product.update_attribute(:terms_id, document.id)
 
     visit pathway_product_path(product.section, product)
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,0 +1,139 @@
+require 'rails_helper'
+
+RSpec.describe Document do
+
+  let(:documentable) { create(:inactive_seller) }
+  let(:attributes) { attributes_for(:document, documentable_id: documentable.id, documentable_type: 'Seller') }
+
+  describe '#valid?' do
+    context 'with all attributes' do
+      subject { Document.new(attributes) }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'without a document' do
+      subject { Document.new(attributes.merge(document: nil)) }
+
+      it 'is invalid' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.keys).to include(:document)
+      end
+    end
+
+    describe 'immutability' do
+      context 'on create' do
+        subject { Document.new(attributes) }
+
+        it 'is valid' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context 'on update with changes' do
+        subject { Document.create!(attributes) }
+
+        before(:each) {
+          subject.original_filename = 'foo.jpg'
+        }
+
+        it 'is invalid' do
+          expect(subject).to_not be_valid
+          expect(subject.errors).to include(:base)
+        end
+      end
+
+      context 'on update with only scan_status changes' do
+        subject { Document.create!(attributes) }
+
+        before(:each) {
+          subject.scan_status = :clean
+        }
+
+        it 'is valid' do
+          expect(subject).to be_valid
+        end
+      end
+    end
+  end
+
+  describe '#scan_status' do
+    it 'is unscanned by default' do
+      expect(Document.new.scan_status).to eq('unscanned')
+    end
+  end
+
+  describe '#mark_as_clean!' do
+    subject { Document.create!(attributes) }
+
+    it 'sets the scan_status to clean' do
+      expect(subject.mark_as_clean!).to be_truthy
+      expect(subject.reload.scan_status).to eq('clean')
+    end
+  end
+
+  describe '#mark_as_infected!' do
+    subject { Document.create!(attributes) }
+
+    it 'sets the scan_status to infected' do
+      expect(subject.mark_as_infected!).to be_truthy
+      expect(subject.reload.scan_status).to eq('infected')
+    end
+  end
+
+  describe '#reset_scan_status!' do
+
+    context 'when infected' do
+      subject { Document.create!(attributes) }
+
+      before(:each) {
+        subject.mark_as_infected!
+      }
+
+      it 'resets the scan_status to unscanned' do
+        expect(subject.reset_scan_status!).to be_truthy
+        expect(subject.reload.scan_status).to eq('unscanned')
+      end
+    end
+
+    context 'when clean' do
+      subject { Document.create!(attributes) }
+
+      before(:each) {
+        subject.mark_as_clean!
+      }
+
+      it 'resets the scan_status to unscanned' do
+        expect(subject.reset_scan_status!).to be_truthy
+        expect(subject.reload.scan_status).to eq('unscanned')
+      end
+    end
+
+  end
+
+  describe '#update_document_attributes' do
+    context 'on create' do
+      subject { Document.create!(attributes).reload }
+      let(:file) { attributes[:document] }
+
+      it 'sets the content_type' do
+        expect(subject.content_type).to eq(file.content_type)
+      end
+
+      it 'sets the original_filename' do
+        expect(subject.original_filename).to eq(file.original_filename)
+      end
+    end
+  end
+
+  describe '#scan_file' do
+    subject { Document.new(attributes) }
+
+    it 'queues the DocumentScanJob on create' do
+      expect(DocumentScanJob).to receive(:perform_later).with(subject)
+      subject.save
+    end
+  end
+end


### PR DESCRIPTION
This migrates associations for seller documents from the `Seller` model to `SellerVersion`. 

To do this, the relationship between `Seller` and `Document` has been redesigned, so that the `SellerVersion` model now stores the ID of the document record corresponding to the file uploaded.

Documents can no longer be changed, and a new file upload will result in a new `Document` model being created (and its ID being assigned).

As the `terms` field on `Product` was sharing the code for documents, I've also migrated this to avoid diverging the codebase.

There is further tidying up to do (eg. removing the reverse association on the `documents` table) but I'd like to get the migration deployed first before we start doing further schema changes.