### PR TITLE
Tidy up documents

### DIFF
--- a/app/models/concerns/documentable.rb
+++ b/app/models/concerns/documentable.rb
@@ -33,12 +33,7 @@ module Concerns::Documentable
           # of the Carrierwave uploader object being re-assigned.
           #
           if file.respond_to?(:tempfile)
-            @updated_documents[field] = Document.new(
-              documentable_type: self.class.name,
-              documentable_id: self.id,
-              kind: field,
-              document: file,
-            )
+            @updated_documents[field] = Document.new(document: file)
           end
         end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,8 +2,6 @@ class Document < ApplicationRecord
   include AASM
   extend Enumerize
 
-  belongs_to :documentable, polymorphic: true
-
   enumerize :scan_status, in: [:unscanned, :clean, :infected]
 
   mount_uploader :document, DocumentUploader
@@ -11,7 +9,7 @@ class Document < ApplicationRecord
   after_commit :scan_file, on: :create
   before_create :update_document_attributes
 
-  validates :kind, :document, :scan_status, presence: true
+  validates :document, :scan_status, presence: true
   validate :force_immutable
 
   aasm column: :scan_status do

--- a/db/migrate/20180806062417_remove_kind_and_documentable_from_documents.rb
+++ b/db/migrate/20180806062417_remove_kind_and_documentable_from_documents.rb
@@ -1,0 +1,7 @@
+class RemoveKindAndDocumentableFromDocuments < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :documents, :documentable_id, :integer, null: false
+    remove_column :documents, :documentable_type, :string, null: false
+    remove_column :documents, :kind, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180803043326) do
+ActiveRecord::Schema.define(version: 20180806062417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,10 +44,7 @@ ActiveRecord::Schema.define(version: 20180803043326) do
   end
 
   create_table "documents", force: :cascade do |t|
-    t.integer "documentable_id", null: false
-    t.string "documentable_type", null: false
     t.string "document"
-    t.string "kind", null: false
     t.string "scan_status", default: "unscanned", null: false
     t.string "original_filename"
     t.string "content_type"

--- a/spec/decorators/product_decorator_spec.rb
+++ b/spec/decorators/product_decorator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ProductDecorator do
 
     context 'when a clean document is present' do
       before(:each) {
-        product.terms = create(:clean_document, documentable: product, kind: 'terms')
+        product.terms = create(:clean_document)
       }
 
       it 'returns true' do
@@ -26,7 +26,7 @@ RSpec.describe ProductDecorator do
 
     context 'when an unscanned document is present' do
       before(:each) {
-        product.terms = create(:unscanned_document, documentable: product, kind: 'terms')
+        product.terms = create(:unscanned_document)
       }
 
       it 'returns false' do
@@ -36,7 +36,7 @@ RSpec.describe ProductDecorator do
 
     context 'when an infected document is present' do
       before(:each) {
-        product.terms = create(:infected_document, documentable: product, kind: 'terms')
+        product.terms = create(:infected_document)
       }
 
       it 'returns false' do

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -1,8 +1,6 @@
 FactoryBot.define do
 
   factory :document do
-    association :documentable, factory: :seller
-    kind 'financial_statement'
     document {
       Rack::Test::UploadedFile.new(
         Rails.root.join('spec', 'fixtures', 'files', 'example.pdf'),

--- a/spec/features/admin_seller_review_spec.rb
+++ b/spec/features/admin_seller_review_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe 'Reviewing seller applications', type: :feature, js: true do
     it 'can see uploaded documents' do
       seller = create(:inactive_seller)
 
-      fs = create(:clean_document, documentable: seller, kind: 'financial_statement')
-      pic = create(:unscanned_document, documentable: seller, kind: 'professional_indemnity_certificate')
-      wcc = create(:infected_document, documentable: seller, kind: 'workers_compensation_certificate')
+      fs = create(:clean_document)
+      pic = create(:unscanned_document)
+      wcc = create(:infected_document)
 
       application = create(:awaiting_assignment_seller_version,
         seller: seller,
@@ -88,7 +88,7 @@ RSpec.describe 'Reviewing seller applications', type: :feature, js: true do
       let!(:product) { create(:inactive_product, :with_basic_details, seller: application.seller) }
 
       context 'for an unscanned document' do
-        let!(:document) { create(:unscanned_document, documentable: product, kind: 'terms') }
+        let!(:document) { create(:unscanned_document) }
 
         before(:example) {
           product.update_attribute(:terms_id, document.id)
@@ -106,7 +106,7 @@ RSpec.describe 'Reviewing seller applications', type: :feature, js: true do
       end
 
       context 'for a clean document' do
-        let!(:document) { create(:clean_document, documentable: product, kind: 'terms') }
+        let!(:document) { create(:clean_document) }
 
         before(:example) {
           product.update_attribute(:terms_id, document.id)
@@ -124,11 +124,11 @@ RSpec.describe 'Reviewing seller applications', type: :feature, js: true do
       end
 
       context 'for an infected document' do
-        let!(:document) { create(:infected_document, documentable: product, kind: 'terms') }
+        let!(:document) { create(:infected_document) }
 
         before(:example) {
           product.update_attribute(:terms_id, document.id)
-          
+
           visit admin_seller_application_path(application)
           click_navigation_item(product.name)
         }

--- a/spec/features/product_profile_spec.rb
+++ b/spec/features/product_profile_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Showing products', type: :feature, js: true do
   end
 
   it 'links to the additional terms' do
-    document = create(:clean_document, documentable: product, kind: 'terms')
+    document = create(:clean_document)
     product.update_attribute(:terms_id, document.id)
 
     visit pathway_product_path(product.section, product)

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Document do
 
   let(:documentable) { create(:inactive_seller) }
-  let(:attributes) { attributes_for(:document, documentable_id: documentable.id, documentable_type: 'Seller') }
+  let(:attributes) { attributes_for(:document) }
 
   describe '#valid?' do
     context 'with all attributes' do


### PR DESCRIPTION
Now that documents have been migrated to the `SellerVersion` model (in #306), and the relationship between documents and their owners simplified, we no longer need to store the `documentable_type`, `documentable_id` or `kind` fields.

This pull request drops these columns from the `documents` table, and makes the supporting changes to the upload behaviour and specs.

As a result, the `documents` table is now really simple, just containing the file, metadata, scan status, and timestamps.