### PR TITLE
Remove composition from seller onboarding contracts

### DIFF
--- a/app/concepts/sellers/seller_version/contract/addresses.rb
+++ b/app/concepts/sellers/seller_version/contract/addresses.rb
@@ -58,26 +58,22 @@ module Sellers::SellerVersion::Contract
     end
 
     validation :default, inherit: true, with: { form: true } do
-      required(:seller_version).schema do
-
-        # NOTE: We have to duplicate the validations here otherwise calling
-        # `valid?` on this form won't actually check if the addresses are valid.
-        #
-        # Likewise, if we remove the validations above, errors won't appear to
-        # users on the form.
-        #
-        required(:addresses).filled(:array?, min_size?: 1) do
-          each do
-            schema do
-              required(:address).filled
-              required(:suburb).filled
-              required(:state).filled
-              required(:postcode).filled
-              required(:country).filled(included_in?: ISO3166::Country.translations.keys)
-            end
+      # NOTE: We have to duplicate the validations here otherwise calling
+      # `valid?` on this form won't actually check if the addresses are valid.
+      #
+      # Likewise, if we remove the validations above, errors won't appear to
+      # users on the form.
+      #
+      required(:addresses).filled(:array?, min_size?: 1) do
+        each do
+          schema do
+            required(:address).filled
+            required(:suburb).filled
+            required(:state).filled
+            required(:postcode).filled
+            required(:country).filled(included_in?: ISO3166::Country.translations.keys)
           end
         end
-
       end
     end
 

--- a/app/concepts/sellers/seller_version/contract/addresses.rb
+++ b/app/concepts/sellers/seller_version/contract/addresses.rb
@@ -30,7 +30,7 @@ module Sellers::SellerVersion::Contract
       collection.append(address)
     end
 
-    collection :addresses, on: :seller_version, prepopulator: AddressPrepopulator, populator: :populate_addresses! do
+    collection :addresses, prepopulator: AddressPrepopulator, populator: :populate_addresses! do
       include Forms::ValidationHelper
 
       def i18n_base

--- a/app/concepts/sellers/seller_version/contract/base.rb
+++ b/app/concepts/sellers/seller_version/contract/base.rb
@@ -1,6 +1,5 @@
 module Sellers::SellerVersion::Contract
   class Base < Reform::Form
-    include Concerns::Contracts::Composition
     include Concerns::Contracts::MultiStepForm
     include Concerns::Contracts::Status
     include Concerns::Contracts::SellerApplication

--- a/app/concepts/sellers/seller_version/contract/base.rb
+++ b/app/concepts/sellers/seller_version/contract/base.rb
@@ -6,7 +6,7 @@ module Sellers::SellerVersion::Contract
     include Forms::ValidationHelper
 
     def upload_for(key)
-      self.model[:seller_version].public_send(key)
+      self.model.public_send(key)
     end
 
     def i18n_base

--- a/app/concepts/sellers/seller_version/contract/business_details.rb
+++ b/app/concepts/sellers/seller_version/contract/business_details.rb
@@ -1,7 +1,7 @@
 module Sellers::SellerVersion::Contract
   class BusinessDetails < Base
-    property :name,         on: :seller_version
-    property :abn,          on: :seller_version
+    property :name
+    property :abn
 
     validation :default, with: {form: true} do
       required(:seller_version).schema do

--- a/app/concepts/sellers/seller_version/contract/business_details.rb
+++ b/app/concepts/sellers/seller_version/contract/business_details.rb
@@ -4,28 +4,26 @@ module Sellers::SellerVersion::Contract
     property :abn
 
     validation :default, with: {form: true} do
-      required(:seller_version).schema do
-        configure do
-          option :form
+      configure do
+        option :form
 
-          def unique_abn?(value)
-            SellerVersion.where.not(seller_id: form.seller.id).where(abn: value).empty?
-          end
-
-          def abn?(value)
-            ABN.valid?(value)
-          end
+        def unique_abn?(value)
+          SellerVersion.where.not(seller_id: form.model.seller_id).where(abn: value).empty?
         end
 
-        required(:name).filled
-        required(:abn).filled
+        def abn?(value)
+          ABN.valid?(value)
+        end
+      end
 
-        rule(abn: [:abn]) do |abn|
-          abn.filled? > abn.unique_abn?
-        end
-        rule(abn: [:abn]) do |abn|
-          abn.filled? > abn.abn?
-        end
+      required(:name).filled
+      required(:abn).filled
+
+      rule(abn: [:abn]) do |abn|
+        abn.filled? > abn.unique_abn?
+      end
+      rule(abn: [:abn]) do |abn|
+        abn.filled? > abn.abn?
       end
     end
   end

--- a/app/concepts/sellers/seller_version/contract/characteristics.rb
+++ b/app/concepts/sellers/seller_version/contract/characteristics.rb
@@ -21,15 +21,13 @@ module Sellers::SellerVersion::Contract
     property :international_government_experience
 
     validation :default do
-      required(:seller_version).schema do
-        # TODO: These don't currently return a nice human-friendly
-        # error message currently
-        required(:number_of_employees).
-          value(included_in?: SellerVersion.number_of_employees.values)
-        required(:corporate_structure).
-          value(included_in?: SellerVersion.corporate_structure.values)
-        required(:regional).filled(:bool?)
-      end
+      # TODO: These don't currently return a nice human-friendly
+      # error message currently
+      required(:number_of_employees).
+        value(included_in?: SellerVersion.number_of_employees.values)
+      required(:corporate_structure).
+        value(included_in?: SellerVersion.corporate_structure.values)
+      required(:regional).filled(:bool?)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/contract/characteristics.rb
+++ b/app/concepts/sellers/seller_version/contract/characteristics.rb
@@ -1,24 +1,24 @@
 module Sellers::SellerVersion::Contract
   class Characteristics < Base
-    property :number_of_employees, on: :seller_version
-    property :corporate_structure, on: :seller_version
+    property :number_of_employees
+    property :corporate_structure
 
-    property :start_up,                            on: :seller_version
-    property :sme,                                 on: :seller_version
-    property :not_for_profit,                      on: :seller_version
+    property :start_up
+    property :sme
+    property :not_for_profit
 
-    property :regional,                            on: :seller_version
+    property :regional
 
-    property :australian_owned,                    on: :seller_version
-    property :disability,                          on: :seller_version
-    property :female_owned,                        on: :seller_version
-    property :indigenous,                          on: :seller_version
+    property :australian_owned
+    property :disability
+    property :female_owned
+    property :indigenous
 
-    property :no_experience,                       on: :seller_version
-    property :local_government_experience,         on: :seller_version
-    property :state_government_experience,         on: :seller_version
-    property :federal_government_experience,       on: :seller_version
-    property :international_government_experience, on: :seller_version
+    property :no_experience
+    property :local_government_experience
+    property :state_government_experience
+    property :federal_government_experience
+    property :international_government_experience
 
     validation :default do
       required(:seller_version).schema do

--- a/app/concepts/sellers/seller_version/contract/contacts.rb
+++ b/app/concepts/sellers/seller_version/contract/contacts.rb
@@ -10,16 +10,14 @@ module Sellers::SellerVersion::Contract
     property :representative_position
 
     validation :default, inherit: true do
-      required(:seller_version).schema do
-        required(:contact_name).filled(:str?)
-        required(:contact_email).filled(:str?, :email?)
-        required(:contact_phone).filled(:str?)
+      required(:contact_name).filled(:str?)
+      required(:contact_email).filled(:str?, :email?)
+      required(:contact_phone).filled(:str?)
 
-        required(:representative_name).filled(:str?)
-        required(:representative_email).filled(:str?, :email?)
-        required(:representative_phone).filled(:str?)
-        required(:representative_position).filled(:str?)
-      end
+      required(:representative_name).filled(:str?)
+      required(:representative_email).filled(:str?, :email?)
+      required(:representative_phone).filled(:str?)
+      required(:representative_position).filled(:str?)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/contract/contacts.rb
+++ b/app/concepts/sellers/seller_version/contract/contacts.rb
@@ -1,13 +1,13 @@
 module Sellers::SellerVersion::Contract
   class Contacts < Base
-    property :contact_name,          on: :seller_version
-    property :contact_email,         on: :seller_version
-    property :contact_phone,         on: :seller_version
+    property :contact_name
+    property :contact_email
+    property :contact_phone
 
-    property :representative_name,     on: :seller_version
-    property :representative_email,    on: :seller_version
-    property :representative_phone,    on: :seller_version
-    property :representative_position, on: :seller_version
+    property :representative_name
+    property :representative_email
+    property :representative_phone
+    property :representative_position
 
     validation :default, inherit: true do
       required(:seller_version).schema do

--- a/app/concepts/sellers/seller_version/contract/declaration.rb
+++ b/app/concepts/sellers/seller_version/contract/declaration.rb
@@ -2,20 +2,18 @@ module Sellers::SellerVersion::Contract
   class Declaration < Base
     def representative_details_provided?
       [:representative_name, :representative_email, :representative_phone, :representative_position].map {|field|
-        seller_version.send(field)
+        model.send(field)
       }.reject(&:present?).empty?
     end
 
     def business_details_provided?
-      seller_version.name.present? && seller_version.abn.present?
+      model.name.present? && model.abn.present?
     end
 
     property :agree
 
     validation :default do
-      required(:seller_version).schema do
-        required(:agree).filled(:bool?, :true?)
-      end
+      required(:agree).filled(:bool?, :true?)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/contract/declaration.rb
+++ b/app/concepts/sellers/seller_version/contract/declaration.rb
@@ -10,7 +10,7 @@ module Sellers::SellerVersion::Contract
       seller_version.name.present? && seller_version.abn.present?
     end
 
-    property :agree, on: :seller_version
+    property :agree
 
     validation :default do
       required(:seller_version).schema do

--- a/app/concepts/sellers/seller_version/contract/disclosures.rb
+++ b/app/concepts/sellers/seller_version/contract/disclosures.rb
@@ -15,39 +15,37 @@ module Sellers::SellerVersion::Contract
     property :other_circumstances_details
 
     validation :default do
-      required(:seller_version).schema do
-        required(:receivership).filled(:bool?)
-        required(:investigations).filled(:bool?)
-        required(:legal_proceedings).filled(:bool?)
-        required(:insurance_claims).filled(:bool?)
-        required(:conflicts_of_interest).filled(:bool?)
-        required(:other_circumstances).filled(:bool?)
+      required(:receivership).filled(:bool?)
+      required(:investigations).filled(:bool?)
+      required(:legal_proceedings).filled(:bool?)
+      required(:insurance_claims).filled(:bool?)
+      required(:conflicts_of_interest).filled(:bool?)
+      required(:other_circumstances).filled(:bool?)
 
-        required(:receivership_details).maybe(:str?)
-        required(:investigations_details).maybe(:str?)
-        required(:legal_proceedings_details).maybe(:str?)
-        required(:insurance_claims_details).maybe(:str?)
-        required(:conflicts_of_interest_details).maybe(:str?)
-        required(:other_circumstances_details).maybe(:str?)
+      required(:receivership_details).maybe(:str?)
+      required(:investigations_details).maybe(:str?)
+      required(:legal_proceedings_details).maybe(:str?)
+      required(:insurance_claims_details).maybe(:str?)
+      required(:conflicts_of_interest_details).maybe(:str?)
+      required(:other_circumstances_details).maybe(:str?)
 
-        rule(receivership_details: [:receivership, :receivership_details]) do |checkbox, details|
-          checkbox.true?.then(details.filled?)
-        end
-        rule(investigations_details: [:investigations, :investigations_details]) do |checkbox, details|
-          checkbox.true?.then(details.filled?)
-        end
-        rule(legal_proceedings_details: [:legal_proceedings, :legal_proceedings_details]) do |checkbox, details|
-          checkbox.true?.then(details.filled?)
-        end
-        rule(insurance_claims_details: [:insurance_claims, :insurance_claims_details]) do |checkbox, details|
-          checkbox.true?.then(details.filled?)
-        end
-        rule(conflicts_of_interest_details: [:conflicts_of_interest, :conflicts_of_interest_details]) do |checkbox, details|
-          checkbox.true?.then(details.filled?)
-        end
-        rule(other_circumstances_details: [:other_circumstances, :other_circumstances_details]) do |checkbox, details|
-          checkbox.true?.then(details.filled?)
-        end
+      rule(receivership_details: [:receivership, :receivership_details]) do |checkbox, details|
+        checkbox.true?.then(details.filled?)
+      end
+      rule(investigations_details: [:investigations, :investigations_details]) do |checkbox, details|
+        checkbox.true?.then(details.filled?)
+      end
+      rule(legal_proceedings_details: [:legal_proceedings, :legal_proceedings_details]) do |checkbox, details|
+        checkbox.true?.then(details.filled?)
+      end
+      rule(insurance_claims_details: [:insurance_claims, :insurance_claims_details]) do |checkbox, details|
+        checkbox.true?.then(details.filled?)
+      end
+      rule(conflicts_of_interest_details: [:conflicts_of_interest, :conflicts_of_interest_details]) do |checkbox, details|
+        checkbox.true?.then(details.filled?)
+      end
+      rule(other_circumstances_details: [:other_circumstances, :other_circumstances_details]) do |checkbox, details|
+        checkbox.true?.then(details.filled?)
       end
     end
   end

--- a/app/concepts/sellers/seller_version/contract/disclosures.rb
+++ b/app/concepts/sellers/seller_version/contract/disclosures.rb
@@ -1,18 +1,18 @@
 module Sellers::SellerVersion::Contract
   class Disclosures < Base
-    property :receivership,          on: :seller_version
-    property :investigations,        on: :seller_version
-    property :legal_proceedings,     on: :seller_version
-    property :insurance_claims,      on: :seller_version
-    property :conflicts_of_interest, on: :seller_version
-    property :other_circumstances,   on: :seller_version
+    property :receivership
+    property :investigations
+    property :legal_proceedings
+    property :insurance_claims
+    property :conflicts_of_interest
+    property :other_circumstances
 
-    property :receivership_details,          on: :seller_version
-    property :investigations_details,        on: :seller_version
-    property :legal_proceedings_details,     on: :seller_version
-    property :insurance_claims_details,      on: :seller_version
-    property :conflicts_of_interest_details, on: :seller_version
-    property :other_circumstances_details,   on: :seller_version
+    property :receivership_details
+    property :investigations_details
+    property :legal_proceedings_details
+    property :insurance_claims_details
+    property :conflicts_of_interest_details
+    property :other_circumstances_details
 
     validation :default do
       required(:seller_version).schema do

--- a/app/concepts/sellers/seller_version/contract/financial_statement.rb
+++ b/app/concepts/sellers/seller_version/contract/financial_statement.rb
@@ -3,9 +3,9 @@ module Sellers::SellerVersion::Contract
     feature Reform::Form::ActiveModel::FormBuilderMethods
     feature Reform::Form::MultiParameterAttributes
 
-    property :financial_statement_file,   on: :seller_version
-    property :financial_statement_expiry, on: :seller_version, multi_params: true
-    property :remove_financial_statement, on: :seller_version
+    property :financial_statement_file
+    property :financial_statement_expiry, multi_params: true
+    property :remove_financial_statement
 
     validation :default, inherit: true do
       required(:seller_version).schema do

--- a/app/concepts/sellers/seller_version/contract/financial_statement.rb
+++ b/app/concepts/sellers/seller_version/contract/financial_statement.rb
@@ -8,10 +8,8 @@ module Sellers::SellerVersion::Contract
     property :remove_financial_statement
 
     validation :default, inherit: true do
-      required(:seller_version).schema do
-        required(:financial_statement_file).filled(:file?)
-        required(:financial_statement_expiry).filled(:date?)
-      end
+      required(:financial_statement_file).filled(:file?)
+      required(:financial_statement_expiry).filled(:date?)
     end
 
     def started?

--- a/app/concepts/sellers/seller_version/contract/product_liability.rb
+++ b/app/concepts/sellers/seller_version/contract/product_liability.rb
@@ -39,17 +39,15 @@ module Sellers::SellerVersion::Contract
         end
       end
 
-      required(:seller_version).schema do
-        required(:product_liability_certificate_file, Types::File).maybe(:file_uploaded?)
-        required(:product_liability_certificate_expiry, Types::Date).maybe(:date?, :in_future?)
+      required(:product_liability_certificate_file, Types::File).maybe(:file_uploaded?)
+      required(:product_liability_certificate_expiry, Types::Date).maybe(:date?, :in_future?)
 
-        rule(product_liability_certificate_file: [:product_liability_certificate_file, :product_liability_certificate_expiry]) do |file, expiry|
-          expiry.filled?.then(file.filled?)
-        end
+      rule(product_liability_certificate_file: [:product_liability_certificate_file, :product_liability_certificate_expiry]) do |file, expiry|
+        expiry.filled?.then(file.filled?)
+      end
 
-        rule(product_liability_certificate_expiry: [:product_liability_certificate_file, :product_liability_certificate_expiry]) do |file, expiry|
-          file.filled?.then(expiry.filled?)
-        end
+      rule(product_liability_certificate_expiry: [:product_liability_certificate_file, :product_liability_certificate_expiry]) do |file, expiry|
+        file.filled?.then(expiry.filled?)
       end
     end
 

--- a/app/concepts/sellers/seller_version/contract/product_liability.rb
+++ b/app/concepts/sellers/seller_version/contract/product_liability.rb
@@ -3,9 +3,9 @@ module Sellers::SellerVersion::Contract
     feature Reform::Form::ActiveModel::FormBuilderMethods
     feature Reform::Form::MultiParameterAttributes
 
-    property :product_liability_certificate_file,   on: :seller_version
-    property :product_liability_certificate_expiry, on: :seller_version, multi_params: true
-    property :remove_product_liability_certificate, on: :seller_version
+    property :product_liability_certificate_file
+    property :product_liability_certificate_expiry, multi_params: true
+    property :remove_product_liability_certificate
 
     module Types
       include Dry::Types.module

--- a/app/concepts/sellers/seller_version/contract/professional_indemnity.rb
+++ b/app/concepts/sellers/seller_version/contract/professional_indemnity.rb
@@ -3,9 +3,9 @@ module Sellers::SellerVersion::Contract
     feature Reform::Form::ActiveModel::FormBuilderMethods
     feature Reform::Form::MultiParameterAttributes
 
-    property :professional_indemnity_certificate_file,   on: :seller_version
-    property :professional_indemnity_certificate_expiry, on: :seller_version, multi_params: true
-    property :remove_professional_indemnity_certificate, on: :seller_version
+    property :professional_indemnity_certificate_file
+    property :professional_indemnity_certificate_expiry, multi_params: true
+    property :remove_professional_indemnity_certificate
 
     validation :default, inherit: true do
       required(:seller_version).schema do

--- a/app/concepts/sellers/seller_version/contract/professional_indemnity.rb
+++ b/app/concepts/sellers/seller_version/contract/professional_indemnity.rb
@@ -8,10 +8,8 @@ module Sellers::SellerVersion::Contract
     property :remove_professional_indemnity_certificate
 
     validation :default, inherit: true do
-      required(:seller_version).schema do
-        required(:professional_indemnity_certificate_file).filled(:file?)
-        required(:professional_indemnity_certificate_expiry).filled(:date?, :in_future?)
-      end
+      required(:professional_indemnity_certificate_file).filled(:file?)
+      required(:professional_indemnity_certificate_expiry).filled(:date?, :in_future?)
     end
 
     def started?

--- a/app/concepts/sellers/seller_version/contract/profile_basics.rb
+++ b/app/concepts/sellers/seller_version/contract/profile_basics.rb
@@ -5,11 +5,9 @@ module Sellers::SellerVersion::Contract
     property :linkedin_url
 
     validation :default, inherit: true  do
-      required(:seller_version).schema do
-        required(:summary).filled(max_word_count?: 50)
-        required(:website_url).filled(:url?)
-        optional(:linkedin_url).maybe(:str?, :url?)
-      end
+      required(:summary).filled(max_word_count?: 50)
+      required(:website_url).filled(:url?)
+      optional(:linkedin_url).maybe(:str?, :url?)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/contract/profile_basics.rb
+++ b/app/concepts/sellers/seller_version/contract/profile_basics.rb
@@ -1,8 +1,8 @@
 module Sellers::SellerVersion::Contract
   class ProfileBasics < Base
-    property :summary,      on: :seller_version
-    property :website_url,  on: :seller_version
-    property :linkedin_url, on: :seller_version
+    property :summary
+    property :website_url
+    property :linkedin_url
 
     validation :default, inherit: true  do
       required(:seller_version).schema do

--- a/app/concepts/sellers/seller_version/contract/recognition.rb
+++ b/app/concepts/sellers/seller_version/contract/recognition.rb
@@ -49,9 +49,9 @@ module Sellers::SellerVersion::Contract
       }
     end
 
-    collection :accreditations, on: :seller_version, prepopulator: AccreditationPrepopulator
-    collection :awards, on: :seller_version, prepopulator: AwardPrepopulator
-    collection :engagements, on: :seller_version, prepopulator: EngagementPrepopulator
+    collection :accreditations, prepopulator: AccreditationPrepopulator
+    collection :awards, prepopulator: AwardPrepopulator
+    collection :engagements, prepopulator: EngagementPrepopulator
 
     validation :default, inherit: true do
       required(:seller_version).schema do

--- a/app/concepts/sellers/seller_version/contract/recognition.rb
+++ b/app/concepts/sellers/seller_version/contract/recognition.rb
@@ -54,11 +54,9 @@ module Sellers::SellerVersion::Contract
     collection :engagements, prepopulator: EngagementPrepopulator
 
     validation :default, inherit: true do
-      required(:seller_version).schema do
-        required(:accreditations).value(max_items?: 10)
-        required(:awards).value(max_items?: 10)
-        required(:engagements).value(max_items?: 10)
-      end
+      required(:accreditations).value(max_items?: 10)
+      required(:awards).value(max_items?: 10)
+      required(:engagements).value(max_items?: 10)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/contract/services.rb
+++ b/app/concepts/sellers/seller_version/contract/services.rb
@@ -41,7 +41,7 @@ module Sellers::SellerVersion::Contract
 
       required(:services).maybe(one_of?: SellerVersion.services.values)
       required(:govdc).filled(:bool?)
-      optional(:offers_cloud).filled(:bool?)
+      optional(:offers_cloud).maybe(:bool?)
 
       rule(services: [:offers_cloud, :services]) do |offers_cloud, services|
         offers_cloud.true?.then(services.filled?)

--- a/app/concepts/sellers/seller_version/contract/services.rb
+++ b/app/concepts/sellers/seller_version/contract/services.rb
@@ -35,26 +35,24 @@ module Sellers::SellerVersion::Contract
         end
 
         def has_no_products?
-          form.seller.products.empty?
+          form.model.seller.products.empty?
         end
       end
 
-      required(:seller_version).schema do
-        required(:services).maybe(one_of?: SellerVersion.services.values)
-        required(:govdc).filled(:bool?)
-        optional(:offers_cloud).filled(:bool?)
+      required(:services).maybe(one_of?: SellerVersion.services.values)
+      required(:govdc).filled(:bool?)
+      optional(:offers_cloud).filled(:bool?)
 
-        rule(services: [:offers_cloud, :services]) do |offers_cloud, services|
-          offers_cloud.true?.then(services.filled?)
-        end
+      rule(services: [:offers_cloud, :services]) do |offers_cloud, services|
+        offers_cloud.true?.then(services.filled?)
+      end
 
-        validate(no_cloud_products?: [:services, :offers_cloud]) do |services, offers_cloud|
-          services.include?('cloud-services') || has_no_products?
-        end
+      validate(no_cloud_products?: [:services, :offers_cloud]) do |services, offers_cloud|
+        services.include?('cloud-services') || has_no_products?
+      end
 
-        rule(eligible_seller: [:services, :govdc]) do |services, govdc|
-          services.offers_cloud? | govdc.true?
-        end
+      rule(eligible_seller: [:services, :govdc]) do |services, govdc|
+        services.offers_cloud? | govdc.true?
       end
     end
   end

--- a/app/concepts/sellers/seller_version/contract/services.rb
+++ b/app/concepts/sellers/seller_version/contract/services.rb
@@ -1,8 +1,8 @@
 module Sellers::SellerVersion::Contract
   class Services < Base
     property :offers_cloud, virtual: true
-    property :services, on: :seller_version
-    property :govdc, on: :seller_version
+    property :services
+    property :govdc
 
     def offers_cloud
       self.services.any? ? self.services.include?('cloud-services') : nil

--- a/app/concepts/sellers/seller_version/contract/workers_compensation.rb
+++ b/app/concepts/sellers/seller_version/contract/workers_compensation.rb
@@ -3,10 +3,10 @@ module Sellers::SellerVersion::Contract
     feature Reform::Form::ActiveModel::FormBuilderMethods
     feature Reform::Form::MultiParameterAttributes
 
-    property :workers_compensation_certificate_file,   on: :seller_version
-    property :workers_compensation_certificate_expiry, on: :seller_version, multi_params: true
-    property :workers_compensation_exempt,             on: :seller_version
-    property :remove_workers_compensation_certificate, on: :seller_version
+    property :workers_compensation_certificate_file
+    property :workers_compensation_certificate_expiry, multi_params: true
+    property :workers_compensation_exempt
+    property :remove_workers_compensation_certificate
 
     # NOTE: Trying to implement conditional validation on this model has been
     # painstaking, but the following does work.

--- a/app/concepts/sellers/seller_version/contract/workers_compensation.rb
+++ b/app/concepts/sellers/seller_version/contract/workers_compensation.rb
@@ -80,24 +80,22 @@ module Sellers::SellerVersion::Contract
         end
       end
 
-      required(:seller_version).schema do
-        # NOTE: When you enable types in Dry-validation, you are then required
-        # to specify the type of all attributes in the schema.
-        #
-        # If you miss an attribute, it will quietly fail and ignore it.
-        #
-        required(:workers_compensation_exempt, Types::Bool).filled
-        required(:workers_compensation_certificate_expiry, Types::Date).maybe(:date?, :in_future?)
+      # NOTE: When you enable types in Dry-validation, you are then required
+      # to specify the type of all attributes in the schema.
+      #
+      # If you miss an attribute, it will quietly fail and ignore it.
+      #
+      required(:workers_compensation_exempt, Types::Bool).filled
+      required(:workers_compensation_certificate_expiry, Types::Date).maybe(:date?, :in_future?)
 
-        required(:workers_compensation_certificate_file, Types::File).maybe(:file_uploaded?)
+      required(:workers_compensation_certificate_file, Types::File).maybe(:file_uploaded?)
 
-        rule(workers_compensation_certificate_expiry: [:workers_compensation_exempt, :workers_compensation_certificate_expiry]) do |exempt, expiry|
-          (exempt.false? | exempt.eql?('0')).then(expiry.filled?)
-        end
+      rule(workers_compensation_certificate_expiry: [:workers_compensation_exempt, :workers_compensation_certificate_expiry]) do |exempt, expiry|
+        (exempt.false? | exempt.eql?('0')).then(expiry.filled?)
+      end
 
-        rule(workers_compensation_certificate_file: [:workers_compensation_exempt, :workers_compensation_certificate_file]) do |exempt, document|
-          (exempt.false? | exempt.eql?('0')).then(document.filled?)
-        end
+      rule(workers_compensation_certificate_file: [:workers_compensation_exempt, :workers_compensation_certificate_file]) do |exempt, document|
+        (exempt.false? | exempt.eql?('0')).then(document.filled?)
       end
     end
   end

--- a/app/concepts/sellers/seller_version/operation/update.rb
+++ b/app/concepts/sellers/seller_version/operation/update.rb
@@ -14,8 +14,7 @@ class Sellers::SellerVersion::Update < Trailblazer::Operation
 
     def contract!(options, **)
       options['contract.default'] = options['config.contract_class'].new(
-        seller_version: options['model.seller_version'],
-        seller: options['model.seller'],
+        options['model.seller_version']
       )
     end
 

--- a/app/concepts/sellers/seller_version/products/contract/availability_support.rb
+++ b/app/concepts/sellers/seller_version/products/contract/availability_support.rb
@@ -1,17 +1,15 @@
 module Sellers::SellerVersion::Products::Contract
   class AvailabilitySupport < Base
-    property :guaranteed_availability, on: :product
-    property :support_options, on: :product
-    property :support_options_additional_cost, on: :product
-    property :support_levels, on: :product
+    property :guaranteed_availability
+    property :support_options
+    property :support_options_additional_cost
+    property :support_levels
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:guaranteed_availability).filled(max_word_count?: 200)
-        required(:support_options).filled(any_checked?: true, one_of?: Product.support_options.values)
-        required(:support_options_additional_cost).filled
-        required(:support_levels).filled(max_word_count?: 200)
-      end
+      required(:guaranteed_availability).filled(max_word_count?: 200)
+      required(:support_options).filled(any_checked?: true, one_of?: Product.support_options.values)
+      required(:support_options_additional_cost).filled
+      required(:support_levels).filled(max_word_count?: 200)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/products/contract/backup_recovery.rb
+++ b/app/concepts/sellers/seller_version/products/contract/backup_recovery.rb
@@ -1,15 +1,13 @@
 module Sellers::SellerVersion::Products::Contract
   class BackupRecovery < Base
-    property :backup_capability, on: :product
-    property :backup_scheduling_type, on: :product
-    property :backup_recovery_type, on: :product
+    property :backup_capability
+    property :backup_scheduling_type
+    property :backup_recovery_type
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:backup_capability).filled(in_list?: Product.backup_capability.values)
-        required(:backup_scheduling_type).filled(in_list?: Product.backup_scheduling_type.values)
-        required(:backup_recovery_type).filled(in_list?: Product.backup_recovery_type.values)
-      end
+      required(:backup_capability).filled(in_list?: Product.backup_capability.values)
+      required(:backup_scheduling_type).filled(in_list?: Product.backup_scheduling_type.values)
+      required(:backup_recovery_type).filled(in_list?: Product.backup_recovery_type.values)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/products/contract/base.rb
+++ b/app/concepts/sellers/seller_version/products/contract/base.rb
@@ -1,6 +1,5 @@
 module Sellers::SellerVersion::Products::Contract
   class Base < Reform::Form
-    include Concerns::Contracts::Composition
     include Concerns::Contracts::MultiStepForm
     include Concerns::Contracts::Status
     include Forms::ValidationHelper
@@ -8,11 +7,11 @@ module Sellers::SellerVersion::Products::Contract
     model :product
 
     def product_id
-      model[:product].id
+      model.id
     end
 
     def upload_for(key)
-      self.model[:product].public_send(key)
+      self.model.public_send(key)
     end
 
     def i18n_base

--- a/app/concepts/sellers/seller_version/products/contract/basics.rb
+++ b/app/concepts/sellers/seller_version/products/contract/basics.rb
@@ -39,17 +39,17 @@ module Sellers::SellerVersion::Products::Contract
       super(values.reject(&:blank?))
     end
 
-    property :name, on: :product
-    property :summary, on: :product
-    property :audiences, on: :product
+    property :name
+    property :summary
+    property :audiences
 
-    property :reseller_type, on: :product
-    property :organisation_resold, on: :product
+    property :reseller_type
+    property :organisation_resold
 
-    property :custom_contact, on: :product
-    property :contact_name, on: :product
-    property :contact_email, on: :product
-    property :contact_phone, on: :product
+    property :custom_contact
+    property :contact_name
+    property :contact_email
+    property :contact_phone
 
     collection :features, on: :product, prepopulator: FeaturePrepopulator, populator: FeaturePopulator do
       property :feature
@@ -59,34 +59,32 @@ module Sellers::SellerVersion::Products::Contract
     end
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:name).filled
-        required(:summary).filled(max_word_count?: 200)
+      required(:name).filled
+      required(:summary).filled(max_word_count?: 200)
 
-        required(:audiences).filled(one_of?: Product.audiences.values, max_size?: 3)
+      required(:audiences).filled(one_of?: Product.audiences.values, max_size?: 3)
 
-        required(:reseller_type).filled
-        required(:organisation_resold).maybe(:str?)
+      required(:reseller_type).filled
+      required(:organisation_resold).maybe(:str?)
 
-        rule(organisation_resold: [:reseller_type, :organisation_resold]) do |type, field|
-          type.excluded_from?(['own-product']).then(field.filled?)
-        end
-
-        required(:custom_contact).filled(:bool?)
-        optional(:contact_name).maybe(:str?)
-        optional(:contact_email).maybe(:str?, :email?)
-        optional(:contact_phone).maybe(:str?)
-
-        rule(contact_name: [:custom_contact, :contact_name]) do |radio, name|
-          radio.true?.then(name.filled?)
-        end
-        rule(contact_email: [:custom_contact, :contact_email]) do |radio, email|
-          radio.true?.then(email.filled?)
-        end
-
-        required(:features).value(max_items?: 10)
-        required(:benefits).value(max_items?: 10)
+      rule(organisation_resold: [:reseller_type, :organisation_resold]) do |type, field|
+        type.excluded_from?(['own-product']).then(field.filled?)
       end
+
+      required(:custom_contact).filled(:bool?)
+      optional(:contact_name).maybe(:str?)
+      optional(:contact_email).maybe(:str?, :email?)
+      optional(:contact_phone).maybe(:str?)
+
+      rule(contact_name: [:custom_contact, :contact_name]) do |radio, name|
+        radio.true?.then(name.filled?)
+      end
+      rule(contact_email: [:custom_contact, :contact_email]) do |radio, email|
+        radio.true?.then(email.filled?)
+      end
+
+      required(:features).value(max_items?: 10)
+      required(:benefits).value(max_items?: 10)
     end
 
   end

--- a/app/concepts/sellers/seller_version/products/contract/commercials.rb
+++ b/app/concepts/sellers/seller_version/products/contract/commercials.rb
@@ -1,26 +1,26 @@
 module Sellers::SellerVersion::Products::Contract
   class Commercials < Base
-    property :free_version, on: :product
-    property :free_version_details, on: :product
+    property :free_version
+    property :free_version_details
 
-    property :free_trial, on: :product
-    property :free_trial_url, on: :product
+    property :free_trial
+    property :free_trial_url
 
-    property :pricing_currency, on: :product
-    property :pricing_currency_other, on: :product
-    property :pricing_min, on: :product
-    property :pricing_max, on: :product
-    property :pricing_unit, on: :product
-    property :pricing_variables, on: :product
-    property :pricing_calculator_url, on: :product
+    property :pricing_currency
+    property :pricing_currency_other
+    property :pricing_min
+    property :pricing_max
+    property :pricing_unit
+    property :pricing_variables
+    property :pricing_calculator_url
 
-    property :education_pricing, on: :product
-    property :education_pricing_eligibility, on: :product
-    property :education_pricing_differences, on: :product
+    property :education_pricing
+    property :education_pricing_eligibility
+    property :education_pricing_differences
 
-    property :not_for_profit_pricing, on: :product
-    property :not_for_profit_pricing_eligibility, on: :product
-    property :not_for_profit_pricing_differences, on: :product
+    property :not_for_profit_pricing
+    property :not_for_profit_pricing_eligibility
+    property :not_for_profit_pricing_differences
 
     validation :default, inherit: true do
       configure do
@@ -33,56 +33,54 @@ module Sellers::SellerVersion::Products::Contract
         end
       end
 
-      required(:product).schema do
-        required(:free_version).filled(:bool?)
-        required(:free_version_details).maybe(max_word_count?: 50)
+      required(:free_version).filled(:bool?)
+      required(:free_version_details).maybe(max_word_count?: 50)
 
-        rule(free_version_details: [:free_version, :free_version_details]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
+      rule(free_version_details: [:free_version, :free_version_details]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
 
-        required(:free_trial).filled(:bool?)
-        required(:free_trial_url).maybe(:str?, :url?)
+      required(:free_trial).filled(:bool?)
+      required(:free_trial_url).maybe(:str?, :url?)
 
-        rule(free_trial_url: [:free_trial, :free_trial_url]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
+      rule(free_trial_url: [:free_trial, :free_trial_url]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
 
-        required(:pricing_currency).filled
-        required(:pricing_currency_other).maybe(:str?, :currency?)
+      required(:pricing_currency).filled
+      required(:pricing_currency_other).maybe(:str?, :currency?)
 
-        rule(pricing_currency_other: [:pricing_currency, :pricing_currency_other]) do |type, field|
-          type.eql?('other').then(field.filled?)
-        end
+      rule(pricing_currency_other: [:pricing_currency, :pricing_currency_other]) do |type, field|
+        type.eql?('other').then(field.filled?)
+      end
 
-        required(:pricing_min).filled(:number?)
-        required(:pricing_max).filled(:number?)
-        required(:pricing_unit).filled(:str?)
+      required(:pricing_min).filled(:number?)
+      required(:pricing_max).filled(:number?)
+      required(:pricing_unit).filled(:str?)
 
-        required(:pricing_variables).filled(:str?)
-        required(:pricing_calculator_url).maybe(:str?, :url?)
+      required(:pricing_variables).filled(:str?)
+      required(:pricing_calculator_url).maybe(:str?, :url?)
 
-        required(:education_pricing).filled(:bool?)
-        required(:education_pricing_eligibility).maybe(:str?)
-        required(:education_pricing_differences).maybe(:str?)
+      required(:education_pricing).filled(:bool?)
+      required(:education_pricing_eligibility).maybe(:str?)
+      required(:education_pricing_differences).maybe(:str?)
 
-        rule(education_pricing_eligibility: [:education_pricing, :education_pricing_eligibility]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(education_pricing_differences: [:education_pricing, :education_pricing_differences]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
+      rule(education_pricing_eligibility: [:education_pricing, :education_pricing_eligibility]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(education_pricing_differences: [:education_pricing, :education_pricing_differences]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
 
-        required(:not_for_profit_pricing).filled(:bool?)
-        required(:not_for_profit_pricing_eligibility).maybe(:str?)
-        required(:not_for_profit_pricing_differences).maybe(:str?)
+      required(:not_for_profit_pricing).filled(:bool?)
+      required(:not_for_profit_pricing_eligibility).maybe(:str?)
+      required(:not_for_profit_pricing_differences).maybe(:str?)
 
-        rule(not_for_profit_pricing_eligibility: [:not_for_profit_pricing, :not_for_profit_pricing_eligibility]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(not_for_profit_pricing_differences: [:not_for_profit_pricing, :not_for_profit_pricing_differences]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
+      rule(not_for_profit_pricing_eligibility: [:not_for_profit_pricing, :not_for_profit_pricing_eligibility]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(not_for_profit_pricing_differences: [:not_for_profit_pricing, :not_for_profit_pricing_differences]) do |radio, field|
+        radio.true?.then(field.filled?)
       end
     end
   end

--- a/app/concepts/sellers/seller_version/products/contract/data_protection.rb
+++ b/app/concepts/sellers/seller_version/products/contract/data_protection.rb
@@ -1,38 +1,36 @@
 module Sellers::SellerVersion::Products::Contract
   class DataProtection < Base
-    property :encryption_transit_user_types, on: :product
-    property :encryption_transit_user_other, on: :product
-    property :encryption_transit_network_types, on: :product
-    property :encryption_transit_network_other, on: :product
-    property :encryption_rest_types, on: :product
-    property :encryption_rest_other, on: :product
-    property :encryption_keys_controller, on: :product
+    property :encryption_transit_user_types
+    property :encryption_transit_user_other
+    property :encryption_transit_network_types
+    property :encryption_transit_network_other
+    property :encryption_rest_types
+    property :encryption_rest_other
+    property :encryption_keys_controller
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:encryption_transit_user_types).filled(any_checked?: true, one_of?: Product.encryption_transit_user_types.values)
-        required(:encryption_transit_user_other).maybe(:str?)
+      required(:encryption_transit_user_types).filled(any_checked?: true, one_of?: Product.encryption_transit_user_types.values)
+      required(:encryption_transit_user_other).maybe(:str?)
 
-        rule(encryption_transit_user_other: [:encryption_transit_user_types, :encryption_transit_user_other]) do |checkboxes, field|
-          checkboxes.contains?('other').then(field.filled?)
-        end
-
-        required(:encryption_transit_network_types).filled(any_checked?: true, one_of?: Product.encryption_transit_network_types.values)
-        required(:encryption_transit_network_other).maybe(:str?)
-
-        rule(encryption_transit_network_other: [:encryption_transit_network_types, :encryption_transit_network_other]) do |checkboxes, field|
-          checkboxes.contains?('other').then(field.filled?)
-        end
-
-        required(:encryption_rest_types).filled(any_checked?: true, one_of?: Product.encryption_rest_types.values)
-        required(:encryption_rest_other).maybe(:str?)
-
-        rule(encryption_rest_other: [:encryption_rest_types, :encryption_rest_other]) do |checkboxes, field|
-          checkboxes.contains?('other').then(field.filled?)
-        end
-
-        required(:encryption_keys_controller).filled(in_list?: Product.encryption_keys_controller.values)
+      rule(encryption_transit_user_other: [:encryption_transit_user_types, :encryption_transit_user_other]) do |checkboxes, field|
+        checkboxes.contains?('other').then(field.filled?)
       end
+
+      required(:encryption_transit_network_types).filled(any_checked?: true, one_of?: Product.encryption_transit_network_types.values)
+      required(:encryption_transit_network_other).maybe(:str?)
+
+      rule(encryption_transit_network_other: [:encryption_transit_network_types, :encryption_transit_network_other]) do |checkboxes, field|
+        checkboxes.contains?('other').then(field.filled?)
+      end
+
+      required(:encryption_rest_types).filled(any_checked?: true, one_of?: Product.encryption_rest_types.values)
+      required(:encryption_rest_other).maybe(:str?)
+
+      rule(encryption_rest_other: [:encryption_rest_types, :encryption_rest_other]) do |checkboxes, field|
+        checkboxes.contains?('other').then(field.filled?)
+      end
+
+      required(:encryption_keys_controller).filled(in_list?: Product.encryption_keys_controller.values)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/products/contract/environment.rb
+++ b/app/concepts/sellers/seller_version/products/contract/environment.rb
@@ -1,106 +1,104 @@
 module Sellers::SellerVersion::Products::Contract
   class Environment < Base
-    property :deployment_model, on: :product
-    property :deployment_model_other, on: :product
+    property :deployment_model
+    property :deployment_model_other
 
-    property :addon_extension_type, on: :product
-    property :addon_extension_details, on: :product
+    property :addon_extension_type
+    property :addon_extension_details
 
-    property :api, on: :product
-    property :api_capabilities, on: :product
-    property :api_automation, on: :product
+    property :api
+    property :api_capabilities
+    property :api_automation
 
-    property :government_network_type, on: :product
-    property :government_network_other, on: :product
+    property :government_network_type
+    property :government_network_other
 
-    property :web_interface, on: :product
-    property :web_interface_details, on: :product
-    property :supported_browsers, on: :product
+    property :web_interface
+    property :web_interface_details
+    property :supported_browsers
 
-    property :installed_application, on: :product
-    property :supported_os, on: :product
-    property :supported_os_other, on: :product
+    property :installed_application
+    property :supported_os
+    property :supported_os_other
 
-    property :mobile_devices, on: :product
-    property :mobile_desktop_differences, on: :product
+    property :mobile_devices
+    property :mobile_desktop_differences
 
-    property :accessibility_type, on: :product
-    property :accessibility_exclusions, on: :product
+    property :accessibility_type
+    property :accessibility_exclusions
 
-    property :scaling_type, on: :product
+    property :scaling_type
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:deployment_model).filled(one_of?: Product.deployment_model.values)
-        required(:deployment_model_other).maybe(:str?)
+      required(:deployment_model).filled(one_of?: Product.deployment_model.values)
+      required(:deployment_model_other).maybe(:str?)
 
-        rule(deployment_model_other: [:deployment_model, :deployment_model_other]) do |checkboxes, field|
-          checkboxes.contains?('other-cloud').then(field.filled?)
-        end
-
-        required(:addon_extension_type).filled(in_list?: Product.addon_extension_type.values)
-        required(:addon_extension_details).maybe(:str?)
-
-        rule(addon_extension_details: [:addon_extension_type, :addon_extension_details]) do |radio, field|
-          ( radio.eql?('yes') | radio.eql?('yes-and-standalone') ).then(field.filled?)
-        end
-
-        required(:api).filled(in_list?: Product.api.values)
-        required(:api_capabilities).maybe(:str?)
-        required(:api_automation).maybe(:str?)
-
-        rule(api_capabilities: [:api, :api_capabilities]) do |radio, field|
-          ( radio.eql?('rest') | radio.eql?('non-rest') ).then(field.filled?)
-        end
-        rule(api_automation: [:api, :api_automation]) do |radio, field|
-          ( radio.eql?('rest') | radio.eql?('non-rest') ).then(field.filled?)
-        end
-
-        required(:government_network_type).filled(one_of?: Product.government_network_type.values)
-        required(:government_network_other).maybe(:str?)
-
-        rule(government_network_other: [:government_network_type, :government_network_other]) do |checkboxes, field|
-          checkboxes.contains?('other').then(field.filled?)
-        end
-
-        required(:web_interface).filled(:bool?)
-        required(:web_interface_details).maybe(:str?)
-        optional(:supported_browsers).maybe(one_of?: Product.supported_browsers.values)
-
-        rule(web_interface_details: [:web_interface, :web_interface_details]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(supported_browsers: [:web_interface, :supported_browsers]) do |radio, field|
-          radio.true?.then(field.filled?.any_checked?)
-        end
-
-        required(:installed_application).filled(:bool?)
-        optional(:supported_os).maybe(one_of?: Product.supported_os.values)
-        required(:supported_os_other).maybe(:str?)
-
-        rule(supported_os: [:installed_application, :supported_os]) do |radio, field|
-          radio.true?.then(field.filled?.any_checked?)
-        end
-        rule(supported_os_other: [:installed_application, :supported_os, :supported_os_other]) do |radio, checkboxes, field|
-          (radio.true? & checkboxes.contains?('other')).then(field.filled?)
-        end
-
-        required(:mobile_devices).filled(:bool?)
-        required(:mobile_desktop_differences).maybe(:str?)
-
-        rule(mobile_desktop_differences: [:mobile_devices, :mobile_desktop_differences]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-
-        required(:accessibility_type).filled(in_list?: Product.accessibility_type.values)
-        required(:accessibility_exclusions).maybe(:str?)
-
-        rule(accessibility_exclusions: [:accessibility_type, :accessibility_exclusions]) do |radio, field|
-          radio.eql?('exclusions').then(field.filled?)
-        end
-
-        required(:scaling_type).filled(in_list?: Product.scaling_type.values)
+      rule(deployment_model_other: [:deployment_model, :deployment_model_other]) do |checkboxes, field|
+        checkboxes.contains?('other-cloud').then(field.filled?)
       end
+
+      required(:addon_extension_type).filled(in_list?: Product.addon_extension_type.values)
+      required(:addon_extension_details).maybe(:str?)
+
+      rule(addon_extension_details: [:addon_extension_type, :addon_extension_details]) do |radio, field|
+        ( radio.eql?('yes') | radio.eql?('yes-and-standalone') ).then(field.filled?)
+      end
+
+      required(:api).filled(in_list?: Product.api.values)
+      required(:api_capabilities).maybe(:str?)
+      required(:api_automation).maybe(:str?)
+
+      rule(api_capabilities: [:api, :api_capabilities]) do |radio, field|
+        ( radio.eql?('rest') | radio.eql?('non-rest') ).then(field.filled?)
+      end
+      rule(api_automation: [:api, :api_automation]) do |radio, field|
+        ( radio.eql?('rest') | radio.eql?('non-rest') ).then(field.filled?)
+      end
+
+      required(:government_network_type).filled(one_of?: Product.government_network_type.values)
+      required(:government_network_other).maybe(:str?)
+
+      rule(government_network_other: [:government_network_type, :government_network_other]) do |checkboxes, field|
+        checkboxes.contains?('other').then(field.filled?)
+      end
+
+      required(:web_interface).filled(:bool?)
+      required(:web_interface_details).maybe(:str?)
+      optional(:supported_browsers).maybe(one_of?: Product.supported_browsers.values)
+
+      rule(web_interface_details: [:web_interface, :web_interface_details]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(supported_browsers: [:web_interface, :supported_browsers]) do |radio, field|
+        radio.true?.then(field.filled?.any_checked?)
+      end
+
+      required(:installed_application).filled(:bool?)
+      optional(:supported_os).maybe(one_of?: Product.supported_os.values)
+      required(:supported_os_other).maybe(:str?)
+
+      rule(supported_os: [:installed_application, :supported_os]) do |radio, field|
+        radio.true?.then(field.filled?.any_checked?)
+      end
+      rule(supported_os_other: [:installed_application, :supported_os, :supported_os_other]) do |radio, checkboxes, field|
+        (radio.true? & checkboxes.contains?('other')).then(field.filled?)
+      end
+
+      required(:mobile_devices).filled(:bool?)
+      required(:mobile_desktop_differences).maybe(:str?)
+
+      rule(mobile_desktop_differences: [:mobile_devices, :mobile_desktop_differences]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+
+      required(:accessibility_type).filled(in_list?: Product.accessibility_type.values)
+      required(:accessibility_exclusions).maybe(:str?)
+
+      rule(accessibility_exclusions: [:accessibility_type, :accessibility_exclusions]) do |radio, field|
+        radio.eql?('exclusions').then(field.filled?)
+      end
+
+      required(:scaling_type).filled(in_list?: Product.scaling_type.values)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/products/contract/identity_authentication.rb
+++ b/app/concepts/sellers/seller_version/products/contract/identity_authentication.rb
@@ -1,22 +1,20 @@
 module Sellers::SellerVersion::Products::Contract
   class IdentityAuthentication < Base
-    property :authentication_required, on: :product
-    property :authentication_types, on: :product
-    property :authentication_other, on: :product
+    property :authentication_required
+    property :authentication_types
+    property :authentication_other
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:authentication_required).filled(:bool?)
+      required(:authentication_required).filled(:bool?)
 
-        required(:authentication_types).maybe(one_of?: Product.authentication_types.values)
-        required(:authentication_other).maybe(:str?, max_word_count?: 200)
+      required(:authentication_types).maybe(one_of?: Product.authentication_types.values)
+      required(:authentication_other).maybe(:str?, max_word_count?: 200)
 
-        rule(authentication_types: [:authentication_required, :authentication_types]) do |radio, field|
-          radio.true?.then(field.filled?.any_checked?)
-        end
-        rule(authentication_other: [:authentication_required, :authentication_types, :authentication_other]) do |radio, checkboxes, field|
-          (radio.true? & checkboxes.contains?('other')).then(field.filled?)
-        end
+      rule(authentication_types: [:authentication_required, :authentication_types]) do |radio, field|
+        radio.true?.then(field.filled?.any_checked?)
+      end
+      rule(authentication_other: [:authentication_required, :authentication_types, :authentication_other]) do |radio, checkboxes, field|
+        (radio.true? & checkboxes.contains?('other')).then(field.filled?)
       end
     end
   end

--- a/app/concepts/sellers/seller_version/products/contract/locations.rb
+++ b/app/concepts/sellers/seller_version/products/contract/locations.rb
@@ -1,45 +1,43 @@
 module Sellers::SellerVersion::Products::Contract
   class Locations < Base
-    property :data_location_control, on: :product
+    property :data_location_control
 
-    property :data_location, on: :product
-    property :data_location_other, on: :product
-    property :data_location_unknown_reason, on: :product
+    property :data_location
+    property :data_location_other
+    property :data_location_unknown_reason
 
-    property :own_data_centre, on: :product
-    property :own_data_centre_details, on: :product
+    property :own_data_centre
+    property :own_data_centre_details
 
-    property :third_party_involved, on: :product
-    property :third_party_involved_details, on: :product
+    property :third_party_involved
+    property :third_party_involved_details
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:data_location_control).filled(:bool?)
+      required(:data_location_control).filled(:bool?)
 
-        required(:data_location).filled(in_list?: Product.data_location.values)
-        required(:data_location_other).maybe(:str?)
-        required(:data_location_unknown_reason).maybe(:str?)
+      required(:data_location).filled(in_list?: Product.data_location.values)
+      required(:data_location_other).maybe(:str?)
+      required(:data_location_unknown_reason).maybe(:str?)
 
-        rule(data_location_other: [:data_location, :data_location_other]) do |radio, field|
-          radio.eql?('other-known').then(field.filled?)
-        end
-        rule(data_location_unknown_reason: [:data_location, :data_location_unknown_reason]) do |radio, field|
-          radio.eql?('dont-know').then(field.filled?)
-        end
+      rule(data_location_other: [:data_location, :data_location_other]) do |radio, field|
+        radio.eql?('other-known').then(field.filled?)
+      end
+      rule(data_location_unknown_reason: [:data_location, :data_location_unknown_reason]) do |radio, field|
+        radio.eql?('dont-know').then(field.filled?)
+      end
 
-        required(:own_data_centre).filled(:bool?)
-        required(:own_data_centre_details).maybe(:str?)
+      required(:own_data_centre).filled(:bool?)
+      required(:own_data_centre_details).maybe(:str?)
 
-        rule(own_data_centre_details: [:own_data_centre, :own_data_centre_details]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
+      rule(own_data_centre_details: [:own_data_centre, :own_data_centre_details]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
 
-        required(:third_party_involved).filled(:bool?)
-        required(:third_party_involved_details).maybe(:str?)
+      required(:third_party_involved).filled(:bool?)
+      required(:third_party_involved_details).maybe(:str?)
 
-        rule(third_party_involved_details: [:third_party_involved, :third_party_involved_details]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
+      rule(third_party_involved_details: [:third_party_involved, :third_party_involved_details]) do |radio, field|
+        radio.true?.then(field.filled?)
       end
     end
   end

--- a/app/concepts/sellers/seller_version/products/contract/onboarding_offboarding.rb
+++ b/app/concepts/sellers/seller_version/products/contract/onboarding_offboarding.rb
@@ -1,13 +1,11 @@
 module Sellers::SellerVersion::Products::Contract
   class OnboardingOffboarding < Base
-    property :onboarding_assistance, on: :product
-    property :offboarding_assistance, on: :product
+    property :onboarding_assistance
+    property :offboarding_assistance
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:onboarding_assistance).filled(max_word_count?: 200)
-        required(:offboarding_assistance).filled(max_word_count?: 200)
-      end
+      required(:onboarding_assistance).filled(max_word_count?: 200)
+      required(:offboarding_assistance).filled(max_word_count?: 200)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/products/contract/operational_security.rb
+++ b/app/concepts/sellers/seller_version/products/contract/operational_security.rb
@@ -1,27 +1,25 @@
 module Sellers::SellerVersion::Products::Contract
   class OperationalSecurity < Base
-    property :change_management_processes, on: :product
-    property :change_management_approach, on: :product
-    property :vulnerability_processes, on: :product
-    property :vulnerability_approach, on: :product
-    property :protective_monitoring_processes, on: :product
-    property :protective_monitoring_approach, on: :product
-    property :incident_management_processes, on: :product
-    property :incident_management_approach, on: :product
-    property :access_control_testing_frequency, on: :product
+    property :change_management_processes
+    property :change_management_approach
+    property :vulnerability_processes
+    property :vulnerability_approach
+    property :protective_monitoring_processes
+    property :protective_monitoring_approach
+    property :incident_management_processes
+    property :incident_management_approach
+    property :access_control_testing_frequency
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:change_management_processes).filled(in_list?: Product.change_management_processes.values)
-        required(:change_management_approach).filled(:str?)
-        required(:vulnerability_processes).filled(in_list?: Product.vulnerability_processes.values)
-        required(:vulnerability_approach).filled(:str?)
-        required(:protective_monitoring_processes).filled(in_list?: Product.protective_monitoring_processes.values)
-        required(:protective_monitoring_approach).filled(:str?)
-        required(:incident_management_processes).filled(in_list?: Product.incident_management_processes.values)
-        required(:incident_management_approach).filled(:str?)
-        required(:access_control_testing_frequency).filled(in_list?: Product.access_control_testing_frequency.values)
-      end
+      required(:change_management_processes).filled(in_list?: Product.change_management_processes.values)
+      required(:change_management_approach).filled(:str?)
+      required(:vulnerability_processes).filled(in_list?: Product.vulnerability_processes.values)
+      required(:vulnerability_approach).filled(:str?)
+      required(:protective_monitoring_processes).filled(in_list?: Product.protective_monitoring_processes.values)
+      required(:protective_monitoring_approach).filled(:str?)
+      required(:incident_management_processes).filled(in_list?: Product.incident_management_processes.values)
+      required(:incident_management_approach).filled(:str?)
+      required(:access_control_testing_frequency).filled(in_list?: Product.access_control_testing_frequency.values)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/products/contract/reporting_analytics.rb
+++ b/app/concepts/sellers/seller_version/products/contract/reporting_analytics.rb
@@ -1,38 +1,36 @@
 module Sellers::SellerVersion::Products::Contract
   class ReportingAnalytics < Base
-    property :metrics_contents, on: :product
-    property :metrics_channel_types, on: :product
-    property :metrics_channel_other, on: :product
+    property :metrics_contents
+    property :metrics_channel_types
+    property :metrics_channel_other
 
-    property :outage_channel_types, on: :product
-    property :outage_channel_other, on: :product
+    property :outage_channel_types
+    property :outage_channel_other
 
-    property :usage_channel_types, on: :product
-    property :usage_channel_other, on: :product
+    property :usage_channel_types
+    property :usage_channel_other
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:metrics_contents).filled(:str?, max_word_count?: 200)
-        required(:metrics_channel_types).filled(any_checked?: true, one_of?: Product.metrics_channel_types.values)
-        required(:metrics_channel_other).maybe(:str?)
+      required(:metrics_contents).filled(:str?, max_word_count?: 200)
+      required(:metrics_channel_types).filled(any_checked?: true, one_of?: Product.metrics_channel_types.values)
+      required(:metrics_channel_other).maybe(:str?)
 
-        rule(metrics_channel_other: [:metrics_channel_types, :metrics_channel_other]) do |checkboxes, field|
-          checkboxes.contains?('other').then(field.filled?)
-        end
+      rule(metrics_channel_other: [:metrics_channel_types, :metrics_channel_other]) do |checkboxes, field|
+        checkboxes.contains?('other').then(field.filled?)
+      end
 
-        required(:outage_channel_types).filled(any_checked?: true, one_of?: Product.outage_channel_types.values)
-        required(:outage_channel_other).maybe(:str?)
+      required(:outage_channel_types).filled(any_checked?: true, one_of?: Product.outage_channel_types.values)
+      required(:outage_channel_other).maybe(:str?)
 
-        rule(outage_channel_other: [:outage_channel_types, :outage_channel_other]) do |checkboxes, field|
-          checkboxes.contains?('other').then(field.filled?)
-        end
+      rule(outage_channel_other: [:outage_channel_types, :outage_channel_other]) do |checkboxes, field|
+        checkboxes.contains?('other').then(field.filled?)
+      end
 
-        required(:usage_channel_types).filled(any_checked?: true, one_of?: Product.usage_channel_types.values)
-        required(:usage_channel_other).maybe(:str?)
+      required(:usage_channel_types).filled(any_checked?: true, one_of?: Product.usage_channel_types.values)
+      required(:usage_channel_other).maybe(:str?)
 
-        rule(usage_channel_other: [:usage_channel_types, :usage_channel_other]) do |checkboxes, field|
-          checkboxes.contains?('other').then(field.filled?)
-        end
+      rule(usage_channel_other: [:usage_channel_types, :usage_channel_other]) do |checkboxes, field|
+        checkboxes.contains?('other').then(field.filled?)
       end
     end
   end

--- a/app/concepts/sellers/seller_version/products/contract/security_practices.rb
+++ b/app/concepts/sellers/seller_version/products/contract/security_practices.rb
@@ -1,15 +1,13 @@
 module Sellers::SellerVersion::Products::Contract
   class SecurityPractices < Base
-    property :secure_development_approach, on: :product
-    property :penetration_testing_frequency, on: :product
-    property :penetration_testing_approach, on: :product
+    property :secure_development_approach
+    property :penetration_testing_frequency
+    property :penetration_testing_approach
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:secure_development_approach).filled(in_list?: Product.secure_development_approach.values)
-        required(:penetration_testing_frequency).filled(in_list?: Product.penetration_testing_frequency.values)
-        required(:penetration_testing_approach).filled(one_of?: Product.penetration_testing_approach.values)
-      end
+      required(:secure_development_approach).filled(in_list?: Product.secure_development_approach.values)
+      required(:penetration_testing_frequency).filled(in_list?: Product.penetration_testing_frequency.values)
+      required(:penetration_testing_approach).filled(one_of?: Product.penetration_testing_approach.values)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/products/contract/security_standards.rb
+++ b/app/concepts/sellers/seller_version/products/contract/security_standards.rb
@@ -3,147 +3,145 @@ module Sellers::SellerVersion::Products::Contract
     feature Reform::Form::ActiveModel::FormBuilderMethods
     feature Reform::Form::MultiParameterAttributes
 
-    property :data_centre_security_standards, on: :product
+    property :data_centre_security_standards
 
-    property :iso_27001, on: :product
-    property :iso_27001_accreditor, on: :product
-    property :iso_27001_date, on: :product, multi_params: true
-    property :iso_27001_exclusions, on: :product
+    property :iso_27001
+    property :iso_27001_accreditor
+    property :iso_27001_date, multi_params: true
+    property :iso_27001_exclusions
 
-    property :iso_27017, on: :product
-    property :iso_27017_accreditor, on: :product
-    property :iso_27017_date, on: :product, multi_params: true
-    property :iso_27017_exclusions, on: :product
+    property :iso_27017
+    property :iso_27017_accreditor
+    property :iso_27017_date, multi_params: true
+    property :iso_27017_exclusions
 
-    property :iso_27018, on: :product
-    property :iso_27018_accreditor, on: :product
-    property :iso_27018_date, on: :product, multi_params: true
-    property :iso_27018_exclusions, on: :product
+    property :iso_27018
+    property :iso_27018_accreditor
+    property :iso_27018_date, multi_params: true
+    property :iso_27018_exclusions
 
-    property :csa_star, on: :product
-    property :csa_star_accreditor, on: :product
-    property :csa_star_date, on: :product, multi_params: true
-    property :csa_star_level, on: :product
-    property :csa_star_exclusions, on: :product
+    property :csa_star
+    property :csa_star_accreditor
+    property :csa_star_date, multi_params: true
+    property :csa_star_level
+    property :csa_star_exclusions
 
-    property :pci_dss, on: :product
-    property :pci_dss_accreditor, on: :product
-    property :pci_dss_date, on: :product, multi_params: true
-    property :pci_dss_exclusions, on: :product
+    property :pci_dss
+    property :pci_dss_accreditor
+    property :pci_dss_date, multi_params: true
+    property :pci_dss_exclusions
 
-    property :soc_2, on: :product
-    property :soc_2_accreditor, on: :product
-    property :soc_2_date, on: :product, multi_params: true
-    property :soc_2_exclusions, on: :product
+    property :soc_2
+    property :soc_2_accreditor
+    property :soc_2_date, multi_params: true
+    property :soc_2_exclusions
 
-    property :irap_type, on: :product
-    property :asd_certified, on: :product
-    property :security_classification_types, on: :product
-    property :security_information_url, on: :product
+    property :irap_type
+    property :asd_certified
+    property :security_classification_types
+    property :security_information_url
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:data_centre_security_standards).filled(in_list?: Product.data_centre_security_standards.values)
+      required(:data_centre_security_standards).filled(in_list?: Product.data_centre_security_standards.values)
 
-        required(:iso_27001).filled(:bool?)
-        required(:iso_27001_accreditor).maybe(:str?)
-        required(:iso_27001_date).maybe(:date?)
-        required(:iso_27001_exclusions).maybe(:str?, max_word_count?: 200)
+      required(:iso_27001).filled(:bool?)
+      required(:iso_27001_accreditor).maybe(:str?)
+      required(:iso_27001_date).maybe(:date?)
+      required(:iso_27001_exclusions).maybe(:str?, max_word_count?: 200)
 
-        rule(iso_27001_accreditor: [:iso_27001, :iso_27001_accreditor]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(iso_27001_date: [:iso_27001, :iso_27001_date]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(iso_27001_exclusions: [:iso_27001, :iso_27001_exclusions]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-
-        required(:iso_27017).filled(:bool?)
-        required(:iso_27017_accreditor).maybe(:str?)
-        required(:iso_27017_date).maybe(:date?)
-        required(:iso_27017_exclusions).maybe(:str?, max_word_count?: 200)
-
-        rule(iso_27017_accreditor: [:iso_27017, :iso_27017_accreditor]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(iso_27017_date: [:iso_27017, :iso_27017_date]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(iso_27017_exclusions: [:iso_27017, :iso_27017_exclusions]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-
-        required(:iso_27018).filled(:bool?)
-        required(:iso_27018_accreditor).maybe(:str?)
-        required(:iso_27018_date).maybe(:date?)
-        required(:iso_27018_exclusions).maybe(:str?, max_word_count?: 200)
-
-        rule(iso_27018_accreditor: [:iso_27018, :iso_27018_accreditor]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(iso_27018_date: [:iso_27018, :iso_27018_date]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(iso_27018_exclusions: [:iso_27018, :iso_27018_exclusions]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-
-        required(:csa_star).filled(:bool?)
-        required(:csa_star_accreditor).maybe(:str?)
-        required(:csa_star_date).maybe(:date?)
-        required(:csa_star_level).maybe(in_list?: Product.csa_star_level.values)
-        required(:csa_star_exclusions).maybe(:str?, max_word_count?: 200)
-
-        rule(csa_star_accreditor: [:csa_star, :csa_star_accreditor]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(csa_star_date: [:csa_star, :csa_star_date]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(csa_star_level: [:csa_star, :csa_star_level]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(csa_star_exclusions: [:csa_star, :csa_star_exclusions]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-
-        required(:pci_dss).filled(:bool?)
-        required(:pci_dss_accreditor).maybe(:str?)
-        required(:pci_dss_date).maybe(:date?)
-        required(:pci_dss_exclusions).maybe(:str?, max_word_count?: 200)
-
-        rule(pci_dss_accreditor: [:pci_dss, :pci_dss_accreditor]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(pci_dss_date: [:pci_dss, :pci_dss_date]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(pci_dss_exclusions: [:pci_dss, :pci_dss_exclusions]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-
-        required(:soc_2).filled(:bool?)
-        required(:soc_2_accreditor).maybe(:str?)
-        required(:soc_2_date).maybe(:date?)
-        required(:soc_2_exclusions).maybe(:str?, max_word_count?: 200)
-
-        rule(soc_2_accreditor: [:soc_2, :soc_2_accreditor]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(soc_2_date: [:soc_2, :soc_2_date]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(soc_2_exclusions: [:soc_2, :soc_2_exclusions]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-
-        required(:irap_type).filled(:str?, in_list?: Product.irap_type.values)
-        required(:asd_certified).filled(:bool?)
-        required(:security_classification_types).filled(one_of?: Product.security_classification_types.values)
-        required(:security_information_url).maybe(:str?, :url?)
+      rule(iso_27001_accreditor: [:iso_27001, :iso_27001_accreditor]) do |radio, field|
+        radio.true?.then(field.filled?)
       end
+      rule(iso_27001_date: [:iso_27001, :iso_27001_date]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(iso_27001_exclusions: [:iso_27001, :iso_27001_exclusions]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+
+      required(:iso_27017).filled(:bool?)
+      required(:iso_27017_accreditor).maybe(:str?)
+      required(:iso_27017_date).maybe(:date?)
+      required(:iso_27017_exclusions).maybe(:str?, max_word_count?: 200)
+
+      rule(iso_27017_accreditor: [:iso_27017, :iso_27017_accreditor]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(iso_27017_date: [:iso_27017, :iso_27017_date]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(iso_27017_exclusions: [:iso_27017, :iso_27017_exclusions]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+
+      required(:iso_27018).filled(:bool?)
+      required(:iso_27018_accreditor).maybe(:str?)
+      required(:iso_27018_date).maybe(:date?)
+      required(:iso_27018_exclusions).maybe(:str?, max_word_count?: 200)
+
+      rule(iso_27018_accreditor: [:iso_27018, :iso_27018_accreditor]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(iso_27018_date: [:iso_27018, :iso_27018_date]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(iso_27018_exclusions: [:iso_27018, :iso_27018_exclusions]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+
+      required(:csa_star).filled(:bool?)
+      required(:csa_star_accreditor).maybe(:str?)
+      required(:csa_star_date).maybe(:date?)
+      required(:csa_star_level).maybe(in_list?: Product.csa_star_level.values)
+      required(:csa_star_exclusions).maybe(:str?, max_word_count?: 200)
+
+      rule(csa_star_accreditor: [:csa_star, :csa_star_accreditor]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(csa_star_date: [:csa_star, :csa_star_date]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(csa_star_level: [:csa_star, :csa_star_level]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(csa_star_exclusions: [:csa_star, :csa_star_exclusions]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+
+      required(:pci_dss).filled(:bool?)
+      required(:pci_dss_accreditor).maybe(:str?)
+      required(:pci_dss_date).maybe(:date?)
+      required(:pci_dss_exclusions).maybe(:str?, max_word_count?: 200)
+
+      rule(pci_dss_accreditor: [:pci_dss, :pci_dss_accreditor]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(pci_dss_date: [:pci_dss, :pci_dss_date]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(pci_dss_exclusions: [:pci_dss, :pci_dss_exclusions]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+
+      required(:soc_2).filled(:bool?)
+      required(:soc_2_accreditor).maybe(:str?)
+      required(:soc_2_date).maybe(:date?)
+      required(:soc_2_exclusions).maybe(:str?, max_word_count?: 200)
+
+      rule(soc_2_accreditor: [:soc_2, :soc_2_accreditor]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(soc_2_date: [:soc_2, :soc_2_date]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(soc_2_exclusions: [:soc_2, :soc_2_exclusions]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+
+      required(:irap_type).filled(:str?, in_list?: Product.irap_type.values)
+      required(:asd_certified).filled(:bool?)
+      required(:security_classification_types).filled(one_of?: Product.security_classification_types.values)
+      required(:security_information_url).maybe(:str?, :url?)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/products/contract/terms.rb
+++ b/app/concepts/sellers/seller_version/products/contract/terms.rb
@@ -1,7 +1,7 @@
 module Sellers::SellerVersion::Products::Contract
   class Terms < Base
-    property :terms_file, on: :product
-    property :remove_terms, on: :product
+    property :terms_file
+    property :remove_terms
 
     def started?
       super do |key, value|

--- a/app/concepts/sellers/seller_version/products/contract/type.rb
+++ b/app/concepts/sellers/seller_version/products/contract/type.rb
@@ -1,11 +1,9 @@
 module Sellers::SellerVersion::Products::Contract
   class Type < Base
-    property :section, on: :product
+    property :section
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:section).filled(in_list?: Product.section.values)
-      end
+      required(:section).filled(in_list?: Product.section.values)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/products/contract/user_data.rb
+++ b/app/concepts/sellers/seller_version/products/contract/user_data.rb
@@ -1,46 +1,44 @@
 module Sellers::SellerVersion::Products::Contract
   class UserData < Base
-    property :data_import_formats, on: :product
-    property :data_import_formats_other, on: :product
-    property :data_export_formats, on: :product
-    property :data_export_formats_other, on: :product
+    property :data_import_formats
+    property :data_import_formats_other
+    property :data_export_formats
+    property :data_export_formats_other
 
-    property :data_access_restrictions, on: :product
-    property :data_access_restrictions_details, on: :product
-    property :audit_information, on: :product
-    property :audit_storage_period, on: :product
-    property :log_storage_period, on: :product
+    property :data_access_restrictions
+    property :data_access_restrictions_details
+    property :audit_information
+    property :audit_storage_period
+    property :log_storage_period
 
-    property :data_disposal_approach, on: :product
+    property :data_disposal_approach
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:data_import_formats).maybe(one_of?: Product.data_import_formats.values)
-        required(:data_import_formats_other).maybe(:str?)
+      required(:data_import_formats).maybe(one_of?: Product.data_import_formats.values)
+      required(:data_import_formats_other).maybe(:str?)
 
-        rule(data_import_formats_other: [:data_import_formats, :data_import_formats_other]) do |checkboxes, field|
-          checkboxes.contains?('other').then(field.filled?)
-        end
-
-        required(:data_export_formats).maybe(one_of?: Product.data_export_formats.values)
-        required(:data_export_formats_other).maybe(:str?)
-
-        rule(data_export_formats_other: [:data_export_formats, :data_export_formats_other]) do |checkboxes, field|
-          checkboxes.contains?('other').then(field.filled?)
-        end
-
-        required(:data_access_restrictions).filled(:bool?)
-        required(:data_access_restrictions_details).maybe(:str?)
-
-        rule(data_access_restrictions_details: [:data_access_restrictions, :data_access_restrictions_details]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-
-        required(:audit_information).filled(:bool?)
-        required(:audit_storage_period).filled(:str?)
-        required(:log_storage_period).filled(:str?)
-        required(:data_disposal_approach).filled(:str?)
+      rule(data_import_formats_other: [:data_import_formats, :data_import_formats_other]) do |checkboxes, field|
+        checkboxes.contains?('other').then(field.filled?)
       end
+
+      required(:data_export_formats).maybe(one_of?: Product.data_export_formats.values)
+      required(:data_export_formats_other).maybe(:str?)
+
+      rule(data_export_formats_other: [:data_export_formats, :data_export_formats_other]) do |checkboxes, field|
+        checkboxes.contains?('other').then(field.filled?)
+      end
+
+      required(:data_access_restrictions).filled(:bool?)
+      required(:data_access_restrictions_details).maybe(:str?)
+
+      rule(data_access_restrictions_details: [:data_access_restrictions, :data_access_restrictions_details]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+
+      required(:audit_information).filled(:bool?)
+      required(:audit_storage_period).filled(:str?)
+      required(:log_storage_period).filled(:str?)
+      required(:data_disposal_approach).filled(:str?)
     end
   end
 end

--- a/app/concepts/sellers/seller_version/products/contract/user_separation.rb
+++ b/app/concepts/sellers/seller_version/products/contract/user_separation.rb
@@ -1,42 +1,40 @@
 module Sellers::SellerVersion::Products::Contract
   class UserSeparation < Base
-    property :virtualisation, on: :product
+    property :virtualisation
 
-    property :virtualisation_implementor, on: :product
-    property :virtualisation_third_party, on: :product
-    property :virtualisation_technologies, on: :product
-    property :virtualisation_technologies_other, on: :product
-    property :user_separation_details, on: :product
+    property :virtualisation_implementor
+    property :virtualisation_third_party
+    property :virtualisation_technologies
+    property :virtualisation_technologies_other
+    property :user_separation_details
 
     validation :default, inherit: true do
-      required(:product).schema do
-        required(:virtualisation).filled(:bool?)
+      required(:virtualisation).filled(:bool?)
 
-        required(:virtualisation_implementor).maybe(in_list?: Product.virtualisation_implementor.values)
-        required(:virtualisation_third_party).maybe(:str?)
+      required(:virtualisation_implementor).maybe(in_list?: Product.virtualisation_implementor.values)
+      required(:virtualisation_third_party).maybe(:str?)
 
-        required(:virtualisation_technologies).maybe(one_of?: Product.virtualisation_technologies.values)
-        required(:virtualisation_technologies_other).maybe(:str?)
+      required(:virtualisation_technologies).maybe(one_of?: Product.virtualisation_technologies.values)
+      required(:virtualisation_technologies_other).maybe(:str?)
 
-        required(:user_separation_details).maybe(:str?, max_word_count?: 100)
+      required(:user_separation_details).maybe(:str?, max_word_count?: 100)
 
-        rule(virtualisation_implementor: [:virtualisation, :virtualisation_implementor]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
-        rule(virtualisation_third_party: [:virtualisation, :virtualisation_implementor, :virtualisation_third_party]) do |radio, implementor, field|
-          (radio.true? & implementor.eql?('third-party')).then(field.filled?)
-        end
+      rule(virtualisation_implementor: [:virtualisation, :virtualisation_implementor]) do |radio, field|
+        radio.true?.then(field.filled?)
+      end
+      rule(virtualisation_third_party: [:virtualisation, :virtualisation_implementor, :virtualisation_third_party]) do |radio, implementor, field|
+        (radio.true? & implementor.eql?('third-party')).then(field.filled?)
+      end
 
-        rule(virtualisation_technologies: [:virtualisation, :virtualisation_technologies]) do |radio, field|
-          radio.true?.then(field.filled?.any_checked?)
-        end
-        rule(virtualisation_technologies_other: [:virtualisation, :virtualisation_technologies, :virtualisation_technologies_other]) do |radio, checkboxes, field|
-          (radio.true? & checkboxes.contains?('other')).then(field.filled?)
-        end
+      rule(virtualisation_technologies: [:virtualisation, :virtualisation_technologies]) do |radio, field|
+        radio.true?.then(field.filled?.any_checked?)
+      end
+      rule(virtualisation_technologies_other: [:virtualisation, :virtualisation_technologies, :virtualisation_technologies_other]) do |radio, checkboxes, field|
+        (radio.true? & checkboxes.contains?('other')).then(field.filled?)
+      end
 
-        rule(user_separation_details: [:virtualisation, :user_separation_details]) do |radio, field|
-          radio.true?.then(field.filled?)
-        end
+      rule(user_separation_details: [:virtualisation, :user_separation_details]) do |radio, field|
+        radio.true?.then(field.filled?)
       end
     end
   end

--- a/app/concepts/sellers/seller_version/products/operation/update.rb
+++ b/app/concepts/sellers/seller_version/products/operation/update.rb
@@ -9,11 +9,7 @@ class Sellers::SellerVersion::Products::Update < Trailblazer::Operation
     end
 
     def contract!(options, **)
-      options['contract.default'] = options['config.contract_class'].new(
-        application: options['model.application'],
-        seller: options['model.seller'],
-        product: options['model.product'],
-      )
+      options['contract.default'] = options['config.contract_class'].new(options['model.product'])
     end
   end
 

--- a/app/concepts/sellers/seller_version/products/operation/update.rb
+++ b/app/concepts/sellers/seller_version/products/operation/update.rb
@@ -19,7 +19,7 @@ class Sellers::SellerVersion::Products::Update < Trailblazer::Operation
   # if they are invalid as we want the user to be able to return later to edit
   # the form.
   #
-  success Contract::Validate( key: :seller_application )
+  success :validate_form!
   step Contract::Persist()
 
   success :expire_progress_cache!
@@ -28,7 +28,11 @@ class Sellers::SellerVersion::Products::Update < Trailblazer::Operation
   # validation errors and show the form again when the fields are invalid.
   #
   step :prepopulate!
-  step Contract::Validate()
+  step :return_valid_state!
+
+  def validate_form!(options, params:, **)
+    options['result.valid'] = options['contract.default'].validate(params[:seller_application])
+  end
 
   def expire_progress_cache!(options, **)
     cache_key = "sellers.products.#{options['model.product'].id}.*"
@@ -38,5 +42,9 @@ class Sellers::SellerVersion::Products::Update < Trailblazer::Operation
   def prepopulate!(options, **)
     contract = options['contract.default']
     contract.prepopulate!
+  end
+
+  def return_valid_state!(options, **)
+    options['result.valid']
   end
 end

--- a/app/presenters/sellers/applications/product_step_presenter.rb
+++ b/app/presenters/sellers/applications/product_step_presenter.rb
@@ -22,11 +22,7 @@ module Sellers::Applications
 
   private
     def build_contract(application, product)
-      contract_class.new(
-        application: application,
-        seller: application.seller,
-        product: product,
-      )
+      contract_class.new(product)
     end
   end
 end

--- a/app/presenters/sellers/applications/step_presenter.rb
+++ b/app/presenters/sellers/applications/step_presenter.rb
@@ -54,10 +54,7 @@ module Sellers::Applications
 
   private
     def build_contract(version)
-      contract_class.new(
-        seller_version: version,
-        seller: version.seller,
-      )
+      contract_class.new(version)
     end
   end
 end

--- a/app/views/sellers/applications/forms/_declaration.html.erb
+++ b/app/views/sellers/applications/forms/_declaration.html.erb
@@ -3,10 +3,10 @@
     <h2>You can't accept the ProcureIT Contracting Framework</h2>
 
     <% if errors['not_authorised_representative'] %>
-      <p>Only <strong><%= f.object.seller_version.representative_email %></strong> can accept the ProcureIT Contracting Framework on behalf of your organisation.</p>
+      <p>Only <strong><%= f.object.model.representative_email %></strong> can accept the ProcureIT Contracting Framework on behalf of your organisation.</p>
 
-      <% unless f.object.seller_version.owners.map(&:email).include?(f.object.seller_version.representative_email) %>
-        <p>You need to <%= link_to 'invite them to your seller account', new_sellers_application_invitation_path(application, email: f.object.seller_version.representative_email) %> and ask them to sign in to accept the terms.</p>
+      <% unless f.object.model.owners.map(&:email).include?(f.object.model.representative_email) %>
+        <p>You need to <%= link_to 'invite them to your seller account', new_sellers_application_invitation_path(application, email: f.object.model.representative_email) %> and ask them to sign in to accept the terms.</p>
       <% else %>
         <p>They have already been invited to sign in and accept the terms.</p>
       <% end %>
@@ -30,9 +30,9 @@
 
 <p>You acknowledge that this is an application to join the ICT Services Scheme, and agree to abide by its <%= link_to 'rules', 'https://www.procurepoint.nsw.gov.au/scm0020' %>.</p>
 
-<% if f.object.seller_version.agree == true %>
+<% if f.object.model.agree == true %>
 
-  <p>The ProcureIT Contracting Framework was agreed to at <strong><%= f.object.seller_version.agreed_at.localtime.to_formatted_s(:long) %></strong><% if f.object.seller_version.agreed_by.present? %> by <strong><%= f.object.seller_version.agreed_by.email %></strong><% end %>.</p>
+  <p>The ProcureIT Contracting Framework was agreed to at <strong><%= f.object.model.agreed_at.localtime.to_formatted_s(:long) %></strong><% if f.object.model.agreed_by.present? %> by <strong><%= f.object.model.agreed_by.email %></strong><% end %>.</p>
   <p class="return-link">
     <%= link_to 'Return to application', sellers_application_path(application), class: 'btn btn-primary' %>
   </p>
@@ -44,9 +44,9 @@
         error: false,
         error_html: false,
         label: t('agree_html', scope: [:sellers, :applications, :steps, :declaration],
-          name: f.object.seller_version.representative_name,
-          organisation: f.object.seller_version.name,
-          abn: f.object.seller_version.abn) %>
+          name: f.object.model.representative_name,
+          organisation: f.object.model.name,
+          abn: f.object.model.abn) %>
 
   <fieldset class="actions">
     <%= f.submit step.button_label(default: 'Save and continue'), class: 'btn btn-primary' %>

--- a/spec/concepts/sellers/seller_version/contract/addresses_spec.rb
+++ b/spec/concepts/sellers/seller_version/contract/addresses_spec.rb
@@ -1,10 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Sellers::SellerVersion::Contract::Addresses do
-  let(:seller) { build_stubbed(:inactive_seller) }
-  let(:version) { build_stubbed(:seller_version, seller: seller) }
-
-  subject { described_class.new(seller_version: version, seller: seller) }
+  let(:version) { build_stubbed(:seller_version) }
+  subject { described_class.new(version) }
 
   let(:atts) {
     {
@@ -79,8 +77,7 @@ RSpec.describe Sellers::SellerVersion::Contract::Addresses do
 
   describe '#addresses' do
     let(:addresses) { [ address_atts ] * 3 }
-    let(:version) { build_stubbed(:seller_version, seller: seller, addresses: addresses) }
-
+    
     it 'adds a new address' do
       subject.validate({
         addresses: addresses + [address_atts],

--- a/spec/concepts/sellers/seller_version/contract/business_details_spec.rb
+++ b/spec/concepts/sellers/seller_version/contract/business_details_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Sellers::SellerVersion::Contract::BusinessDetails do
   let(:seller) { create(:inactive_seller) }
   let(:version) { build_stubbed(:seller_version, seller: seller) }
 
-  subject { described_class.new(seller_version: version, seller: seller) }
+  subject { described_class.new(version) }
 
   let(:atts) {
     {
@@ -35,7 +35,7 @@ RSpec.describe Sellers::SellerVersion::Contract::BusinessDetails do
     subject.validate(atts.merge(abn: '10 123 456 789'))
 
     expect(subject).to_not be_valid
-    expect(subject.errors[:abn].count).to eq(1)
+    expect(subject.errors[:abn]).to be_present
   end
 
   it 'is also valid when the ABN has no spaces' do

--- a/spec/concepts/sellers/seller_version/contract/characteristics_spec.rb
+++ b/spec/concepts/sellers/seller_version/contract/characteristics_spec.rb
@@ -1,10 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Sellers::SellerVersion::Contract::Characteristics do
-  let(:seller) { build_stubbed(:inactive_seller) }
-  let(:version) { build_stubbed(:seller_version, seller: seller) }
+  let(:version) { build_stubbed(:seller_version) }
 
-  subject { described_class.new(seller_version: version, seller: seller) }
+  subject { described_class.new(version) }
 
   let(:atts) {
     {

--- a/spec/concepts/sellers/seller_version/contract/contacts_spec.rb
+++ b/spec/concepts/sellers/seller_version/contract/contacts_spec.rb
@@ -1,10 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Sellers::SellerVersion::Contract::Contacts do
-  let(:seller) { build_stubbed(:inactive_seller) }
-  let(:version) { build_stubbed(:seller_version, seller: seller) }
+  let(:version) { build_stubbed(:seller_version) }
 
-  subject { described_class.new(seller_version: version, seller: seller) }
+  subject { described_class.new(version) }
 
   let(:atts) {
     {

--- a/spec/concepts/sellers/seller_version/contract/declaration_spec.rb
+++ b/spec/concepts/sellers/seller_version/contract/declaration_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Sellers::SellerVersion::Contract::Declaration do
-
   let(:seller_version) { build_stubbed(:seller_version) }
-  subject { described_class.new(seller_version: seller_version, seller: seller_version.seller) }
+  subject { described_class.new(seller_version) }
 
   it 'validates with terms acceptance' do
     expect(subject.validate({

--- a/spec/concepts/sellers/seller_version/contract/disclosures_spec.rb
+++ b/spec/concepts/sellers/seller_version/contract/disclosures_spec.rb
@@ -1,10 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Sellers::SellerVersion::Contract::Disclosures do
-  let(:seller) { build_stubbed(:inactive_seller) }
-  let(:version) { build_stubbed(:seller_version, seller: seller) }
-
-  subject { described_class.new(seller_version: version, seller: seller) }
+  let(:version) { build_stubbed(:seller_version) }
+  subject { described_class.new(version) }
 
   let(:atts) {
     {

--- a/spec/concepts/sellers/seller_version/contract/financial_statement_spec.rb
+++ b/spec/concepts/sellers/seller_version/contract/financial_statement_spec.rb
@@ -1,10 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Sellers::SellerVersion::Contract::FinancialStatement do
-  let(:seller) { create(:inactive_seller) }
-  let(:version) { create(:seller_version, seller: seller) }
-
-  subject { described_class.new(seller_version: version, seller: seller) }
+  let(:version) { create(:seller_version) }
+  subject { described_class.new(version) }
 
   let(:example_pdf) {
     Rack::Test::UploadedFile.new(

--- a/spec/concepts/sellers/seller_version/contract/product_liability_spec.rb
+++ b/spec/concepts/sellers/seller_version/contract/product_liability_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Sellers::SellerVersion::Contract::ProductLiability do
-
   let(:version) { build_stubbed(:seller_version) }
-  subject { described_class.new(seller_version: version, seller: version.seller) }
+  subject { described_class.new(version) }
 
   let(:example_pdf) {
     Rack::Test::UploadedFile.new(

--- a/spec/concepts/sellers/seller_version/contract/professional_indemnity_spec.rb
+++ b/spec/concepts/sellers/seller_version/contract/professional_indemnity_spec.rb
@@ -1,10 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Sellers::SellerVersion::Contract::ProfessionalIndemnity do
-  let(:seller) { create(:inactive_seller) }
-  let(:version) { create(:seller_version, seller: seller) }
-
-  subject { described_class.new(seller_version: version, seller: seller) }
+  let(:version) { create(:seller_version) }
+  subject { described_class.new(version) }
 
   let(:example_pdf) {
     Rack::Test::UploadedFile.new(

--- a/spec/concepts/sellers/seller_version/contract/profile_basics_spec.rb
+++ b/spec/concepts/sellers/seller_version/contract/profile_basics_spec.rb
@@ -1,10 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Sellers::SellerVersion::Contract::ProfileBasics do
-  let(:seller) { build_stubbed(:inactive_seller) }
-  let(:version) { build_stubbed(:seller_version, seller: seller) }
-
-  subject { described_class.new(seller_version: version, seller: seller) }
+  let(:version) { build_stubbed(:seller_version) }
+  subject { described_class.new(version) }
 
   let(:atts) {
     {

--- a/spec/concepts/sellers/seller_version/contract/recognition_spec.rb
+++ b/spec/concepts/sellers/seller_version/contract/recognition_spec.rb
@@ -1,10 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Sellers::SellerVersion::Contract::Recognition do
-  let(:seller) { create(:inactive_seller) }
-  let(:version) { create(:seller_version, seller: seller) }
-
-  subject { described_class.new(seller_version: version, seller: seller) }
+  let(:version) { create(:seller_version) }
+  subject { described_class.new(version) }
 
   let(:atts) {
     {

--- a/spec/concepts/sellers/seller_version/contract/services_spec.rb
+++ b/spec/concepts/sellers/seller_version/contract/services_spec.rb
@@ -1,10 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Sellers::SellerVersion::Contract::Services do
-  let(:seller) { create(:inactive_seller) }
-  let(:version) { create(:seller_version, seller: seller) }
-
-  subject { described_class.new(seller_version: version, seller: seller) }
+  let(:version) { create(:seller_version) }
+  subject { described_class.new(version) }
 
   let(:atts) {
     {
@@ -94,7 +92,7 @@ RSpec.describe Sellers::SellerVersion::Contract::Services do
   end
 
   it 'is invalid when "offers_cloud" is false and there are products' do
-    create(:product, seller: seller)
+    create(:product, seller: version.seller)
     subject.validate(atts.merge(offers_cloud: 'false', govdc: 'true'))
 
     expect(subject).to_not be_valid

--- a/spec/concepts/sellers/seller_version/contract/workers_compensation_spec.rb
+++ b/spec/concepts/sellers/seller_version/contract/workers_compensation_spec.rb
@@ -1,10 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Sellers::SellerVersion::Contract::WorkersCompensation do
-  let(:seller) { create(:inactive_seller) }
-  let(:version) { create(:seller_version, seller: seller) }
-
-  subject { described_class.new(seller_version: version, seller: seller) }
+  let(:version) { create(:seller_version) }
+  subject { described_class.new(version) }
 
   let(:example_pdf) {
     Rack::Test::UploadedFile.new(

--- a/spec/concepts/sellers/seller_version/products/contract/basics_spec.rb
+++ b/spec/concepts/sellers/seller_version/products/contract/basics_spec.rb
@@ -2,9 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Sellers::SellerVersion::Products::Contract::Basics do
   let(:product) { build_stubbed(:inactive_product) }
-  let(:application) { build_stubbed(:created_seller_version) }
-
-  subject { described_class.new(application: application, product: product) }
+  subject { described_class.new(product) }
 
   let(:atts) {
     {

--- a/spec/concepts/sellers/seller_version/products/contract/commercials_spec.rb
+++ b/spec/concepts/sellers/seller_version/products/contract/commercials_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Sellers::SellerVersion::Products::Contract::Commercials do
   let(:product) { build_stubbed(:inactive_product) }
-
-  subject { described_class.new(product: product) }
+  subject { described_class.new(product) }
 
   let(:atts) {
     {

--- a/spec/models/seller_application_progress_report_spec.rb
+++ b/spec/models/seller_application_progress_report_spec.rb
@@ -3,25 +3,21 @@ require 'rails_helper'
 RSpec.describe SellerApplicationProgressReport do
 
   class BaseStepOne < Sellers::SellerVersion::Contract::Base
-    property :name, on: :seller_version
+    property :name
 
     validation :default do
-      required(:seller_version).schema do
-        required(:name).filled
-      end
+      required(:name).filled
     end
   end
   class BaseStepTwo < Sellers::SellerVersion::Contract::Base
-    property :contact_name, on: :seller_version
+    property :contact_name
 
     validation :default do
-      required(:seller_version).schema do
-        required(:contact_name).filled
-      end
+      required(:contact_name).filled
     end
   end
 
-  class ProductStepOne < Sellers::SellerVersion::Contract::Base
+  class ProductStepOne < Sellers::SellerVersion::Products::Contract::Base
     property :name, on: :product
 
     validation :default do
@@ -30,7 +26,7 @@ RSpec.describe SellerApplicationProgressReport do
       end
     end
   end
-  class ProductStepTwo < Sellers::SellerVersion::Contract::Base
+  class ProductStepTwo < Sellers::SellerVersion::Products::Contract::Base
     property :summary, on: :product
 
     validation :default do

--- a/spec/models/seller_application_progress_report_spec.rb
+++ b/spec/models/seller_application_progress_report_spec.rb
@@ -18,21 +18,17 @@ RSpec.describe SellerApplicationProgressReport do
   end
 
   class ProductStepOne < Sellers::SellerVersion::Products::Contract::Base
-    property :name, on: :product
+    property :name
 
     validation :default do
-      required(:product).schema do
-        required(:name).filled
-      end
+      required(:name).filled
     end
   end
   class ProductStepTwo < Sellers::SellerVersion::Products::Contract::Base
-    property :summary, on: :product
+    property :summary
 
     validation :default do
-      required(:product).schema do
-        required(:summary).filled
-      end
+      required(:summary).filled
     end
   end
 

--- a/spec/presenters/sellers/applications/step_presenter_spec.rb
+++ b/spec/presenters/sellers/applications/step_presenter_spec.rb
@@ -9,10 +9,7 @@ RSpec.describe Sellers::Applications::StepPresenter do
 
   describe '#started?' do
     before(:each) do
-      allow(contract).to receive(:new).with(
-        seller_version: seller_version,
-        seller: seller_version.seller
-      ).and_return(mock_contract)
+      allow(contract).to receive(:new).with(seller_version).and_return(mock_contract)
     end
 
     context 'when the contract is started' do
@@ -34,10 +31,7 @@ RSpec.describe Sellers::Applications::StepPresenter do
 
   describe '#complete?' do
     before(:each) do
-      allow(contract).to receive(:new).with(
-        seller_version: seller_version,
-        seller: seller_version.seller
-      ).and_return(mock_contract)
+      allow(contract).to receive(:new).with(seller_version).and_return(mock_contract)
     end
 
     context 'when validate_optional_steps is false' do


### PR DESCRIPTION
Now that the seller onboarding form objects ('contracts') only amend the `SellerVersion` model, we can remove Reform's composition elements to simplify the behaviour.