### PR TITLE
Migrate Buyer data to BuyerApplication 

### DIFF
--- a/app/concepts/buyers/buyer_application/contract/basic_details.rb
+++ b/app/concepts/buyers/buyer_application/contract/basic_details.rb
@@ -1,10 +1,10 @@
 module Buyers::BuyerApplication::Contract
   class BasicDetails < Base
-    property :name, on: :buyer
-    property :organisation, on: :buyer
+    property :name, on: :application
+    property :organisation, on: :application
 
     validation :default do
-      required(:buyer).schema do
+      required(:application).schema do
         required(:name).filled
         required(:organisation).filled
       end

--- a/app/concepts/buyers/buyer_application/contract/employment_status.rb
+++ b/app/concepts/buyers/buyer_application/contract/employment_status.rb
@@ -1,10 +1,10 @@
 module Buyers::BuyerApplication::Contract
   class EmploymentStatus < Base
-    property :employment_status, on: :buyer
+    property :employment_status, on: :application
 
     validation :default, inherit: true do
-      required(:buyer).schema do
-        required(:employment_status, in_list?: Buyer.employment_status.options).filled
+      required(:application).schema do
+        required(:employment_status, in_list?: BuyerApplication.employment_status.options).filled
       end
     end
   end

--- a/app/concepts/buyers/buyer_application/operation/create.rb
+++ b/app/concepts/buyers/buyer_application/operation/create.rb
@@ -9,7 +9,7 @@ class Buyers::BuyerApplication::Create < Trailblazer::Operation
                               Buyer.new(user: options['current_user'])
 
     options[:application_model] = options[:buyer_model].applications.first ||
-                                    BuyerApplication.new(started_at: Time.now)
+                                    BuyerApplication.new(started_at: Time.now, user: options['current_user'])
   end
 
 

--- a/app/models/buyer.rb
+++ b/app/models/buyer.rb
@@ -1,14 +1,18 @@
 class Buyer < ApplicationRecord
   include AASM
-  extend Enumerize
-
   include Concerns::StateScopes
+
+  ALIAS_FIELDS = [:name, :organisation, :employment_status, :user_id]
+
+  ALIAS_FIELDS.each do |field|
+    define_method(field) do |*args, &block|
+      applications.first&.send(field, *args, &block)
+    end
+  end
 
   belongs_to :user
   has_many :applications, class_name: 'BuyerApplication'
   has_many :product_orders
-
-  enumerize :employment_status, in: ['employee', 'contractor', 'other-eligible']
 
   aasm column: :state do
     state :inactive, initial: true

--- a/app/models/slack_message.rb
+++ b/app/models/slack_message.rb
@@ -17,8 +17,8 @@ class SlackMessage
     message_type_with_button(
       :buyer_application_submitted,
       params: {
-        buyer: application.buyer.name,
-        organisation: application.buyer.organisation
+        buyer: application.name,
+        organisation: application.organisation
       },
       button_url: admin_buyer_application_url(application)
     )

--- a/app/views/buyer_application_mailer/application_approved_email.html.erb
+++ b/app/views/buyer_application_mailer/application_approved_email.html.erb
@@ -1,4 +1,4 @@
-<p>Hello <%= @application.buyer.name %>,</p>
+<p>Hello <%= @application.name %>,</p>
 
 <% if @application.decision_body.present? %>
   <p>Your application to become a buyer was approved with this feedback from our team:</p>

--- a/app/views/buyer_application_mailer/application_rejected_email.html.erb
+++ b/app/views/buyer_application_mailer/application_rejected_email.html.erb
@@ -1,4 +1,4 @@
-<p>Hello <%= @application.buyer.name %>,</p>
+<p>Hello <%= @application.name %>,</p>
 
 <p>Thanks for your application to become a buyer on <strong>buy.nsw</strong>.</p>
 

--- a/app/views/buyer_application_mailer/manager_approval_email.html.erb
+++ b/app/views/buyer_application_mailer/manager_approval_email.html.erb
@@ -1,8 +1,8 @@
 <p>Hello,</p>
 
-<p><%= @application.buyer.name %> (<%= @application.user.email %>) has just applied for a buyer account on <strong>buy.nsw</strong>.</p>
+<p><%= @application.name %> (<%= @application.user.email %>) has just applied for a buyer account on <strong>buy.nsw</strong>.</p>
 
-<p>However, accounts for contractors need approval from their manager.</p> 
+<p>However, accounts for contractors need approval from their manager.</p>
 
 <p>To confirm you are their manager and approve the account, please click the link below.</p>
 

--- a/app/views/buyers/applications/_employment_status.html.erb
+++ b/app/views/buyers/applications/_employment_status.html.erb
@@ -1,4 +1,4 @@
-<%= f.input :employment_status, as: :radio_buttons, collection: Buyer.employment_status.options %>
+<%= f.input :employment_status, as: :radio_buttons, collection: BuyerApplication.employment_status.options %>
 
 <fieldset class="actions">
   <%= f.submit 'Save and continue' %>

--- a/app/views/buyers/applications/_terms.html.erb
+++ b/app/views/buyers/applications/_terms.html.erb
@@ -4,16 +4,16 @@
       <%= t('buyers.applications.steps.terms.intro_html') %>
       <dl>
         <dt><%= t('activemodel.attributes.buyers.buyer_application.contract.basic_details.name') %></dt>
-        <dd><%= operation[:buyer_model].name %></dd>
+        <dd><%= operation[:application_model].name %></dd>
 
         <dt><%= t('activemodel.attributes.buyers.buyer_application.contract.basic_details.organisation') %></dt>
-        <dd><%= operation[:buyer_model].organisation %></dd>
+        <dd><%= operation[:application_model].organisation %></dd>
 
         <dt><%= t('buyers.applications.steps.email_approval.long') %></dt>
         <dd><%= operation[:application_model].application_body %></dd>
 
         <dt><%= t('buyers.applications.steps.employment_status.long') %></dt>
-        <dd><%= operation[:buyer_model].employment_status.text %></dd>
+        <dd><%= operation[:application_model].employment_status.text %></dd>
 
         <% if operation[:application_model].requires_manager_approval? %>
           <dt><%= t('buyers.applications.steps.manager_approval.long') %></dt>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,7 +78,7 @@ en:
     failure:
       unauthenticated: "Please sign in or create an account to continue."
   enumerize:
-    buyer:
+    buyer_application:
       employment_status:
         employee: "I'm a NSW Government employee and need access to buy.nsw to perform my role."
         contractor: "I'm a contractor working in state or local government."

--- a/db/migrate/20180807060320_move_buyer_data_to_buyer_applications.rb
+++ b/db/migrate/20180807060320_move_buyer_data_to_buyer_applications.rb
@@ -1,0 +1,36 @@
+class MoveBuyerDataToBuyerApplications < ActiveRecord::Migration[5.1]
+  FIELDS = [:name, :organisation, :employment_status, :user_id]
+
+  def up
+    change_table :buyer_applications do |t|
+      t.string :name
+      t.string :organisation
+      t.string :employment_status
+      t.integer :user_id
+    end
+    add_foreign_key :buyer_applications, :users, column: :user_id
+
+    all_buyers.each do |buyer|
+      application = BuyerApplication.find_by_buyer_id(buyer['id'])
+
+      application.update_attributes!(
+        buyer.symbolize_keys.slice(*FIELDS)
+      )
+
+      puts "Updated: Buyer ##{buyer['id']} => BuyerApplication ##{application.id}"
+    end
+  end
+
+  def down
+    remove_foreign_key :buyer_applications, column: :user_id
+
+    remove_column :buyer_applications, :name
+    remove_column :buyer_applications, :organisation
+    remove_column :buyer_applications, :employment_status
+    remove_column :buyer_applications, :user_id
+  end
+
+  def all_buyers
+    ActiveRecord::Base.connection.execute('SELECT * FROM buyers')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180806062417) do
+ActiveRecord::Schema.define(version: 20180807060320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,10 @@ ActiveRecord::Schema.define(version: 20180806062417) do
     t.string "manager_email"
     t.datetime "manager_approved_at"
     t.string "manager_approval_token"
+    t.string "name"
+    t.string "organisation"
+    t.string "employment_status"
+    t.integer "user_id"
   end
 
   create_table "buyers", force: :cascade do |t|
@@ -370,6 +374,7 @@ ActiveRecord::Schema.define(version: 20180806062417) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "buyer_applications", "users"
   add_foreign_key "products", "documents", column: "terms_id"
   add_foreign_key "seller_versions", "documents", column: "financial_statement_id"
   add_foreign_key "seller_versions", "documents", column: "product_liability_certificate_id"

--- a/spec/concepts/buyers/buyer_application/operation/create_spec.rb
+++ b/spec/concepts/buyers/buyer_application/operation/create_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Buyers::BuyerApplication::Create do
     expect(result[:buyer_model]).to be_persisted
 
     expect(result[:buyer_model].user).to eq(user)
+    expect(result[:application_model].user).to eq(user)
   end
 
   it 'does not create an additional buyer when one exists' do

--- a/spec/factories/buyer_applications.rb
+++ b/spec/factories/buyer_applications.rb
@@ -1,48 +1,77 @@
 FactoryBot.define do
   factory :buyer_application do
     association :buyer
-    state 'created'
-    application_body 'Text'
+    association :user
 
-    trait :with_completed_buyer_profile do
-      association :buyer, factory: :inactive_completed_buyer
+    state 'created'
+
+    trait :completed do
+      name 'Sarah'
+      organisation 'Organisation Name'
+      application_body 'Text'
+      employment_status 'employee'
+    end
+
+    trait :contractor do
+      employment_status 'contractor'
     end
 
     trait :manager_approval do
+      contractor
+
       manager_name 'Manager Manager'
       manager_email 'manager@example.org'
+    end
+
+    trait :with_manager_approval_token do
       sequence(:manager_approval_token) {|n| n }
     end
 
     trait :created do
       state 'created'
     end
+
     trait :awaiting_manager_approval do
-      state 'awaiting_manager_approval'
+      completed
       manager_approval
+      with_manager_approval_token
+
+      state 'awaiting_manager_approval'
     end
+
     trait :awaiting_assignment do
+      completed
+
       state 'awaiting_assignment'
     end
+    
     trait :ready_for_review do
+      completed
+
       state 'ready_for_review'
     end
 
     trait :approved do
+      completed
+
       state 'approved'
       decision_body 'Welcome'
     end
 
     trait :rejected do
+      completed
+
       state 'rejected'
       decision_body 'Sorry, no.'
     end
 
     factory :created_buyer_application, traits: [:created]
     factory :created_manager_approval_buyer_application, traits: [:created, :manager_approval]
-    factory :awaiting_manager_approval_buyer_application, traits: [:awaiting_manager_approval, :with_completed_buyer_profile]
-    factory :awaiting_assignment_buyer_application, traits: [:awaiting_assignment, :with_completed_buyer_profile]
-    factory :ready_for_review_buyer_application, traits: [:ready_for_review, :with_completed_buyer_profile]
+    factory :completed_buyer_application, traits: [:created, :completed]
+    factory :completed_manager_approval_buyer_application, traits: [:created, :completed, :manager_approval]
+    factory :awaiting_manager_approval_buyer_application, traits: [:awaiting_manager_approval]
+    factory :awaiting_assignment_buyer_application, traits: [:awaiting_assignment]
+    factory :ready_for_review_buyer_application, traits: [:ready_for_review]
     factory :approved_buyer_application, traits: [:approved]
     factory :rejected_buyer_application, traits: [:rejected]
   end

--- a/spec/factories/buyers.rb
+++ b/spec/factories/buyers.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :buyer do
     association :user
-    name 'Sarah'
+
     trait :inactive do
       state :inactive
     end
@@ -10,19 +10,7 @@ FactoryBot.define do
       state :active
     end
 
-    trait :contractor do
-      employment_status 'contractor'
-    end
-
-    trait :completed do
-      name 'Buyer Buyer'
-      organisation 'Organisation Name'
-      employment_status 'employee'
-    end
-
-    factory :active_buyer, traits: [:active, :completed]
+    factory :active_buyer, traits: [:active]
     factory :inactive_buyer, traits: [:inactive]
-    factory :inactive_completed_buyer, traits: [:inactive, :completed]
-    factory :inactive_completed_contractor_buyer, traits: [:inactive, :completed, :contractor]
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -31,18 +31,8 @@ FactoryBot.define do
       roles ['admin']
     end
 
-    trait :with_approved_email do
-      sequence(:email) {|n| "user-#{n}@example.nsw.gov.au" }
-    end
-
-    trait :without_approved_email do
-      sequence(:email) {|n| "user-#{n}@example.org" }
-    end
-
     factory :buyer_user, traits: [:buyer]
     factory :active_buyer_user, traits: [:active_buyer]
-    factory :buyer_user_with_approved_email, traits: [:buyer, :with_approved_email]
-    factory :buyer_user_without_approved_email, traits: [:buyer, :without_approved_email]
 
     factory :seller_user, traits: [:seller]
     factory :seller_user_with_seller, traits: [:seller, :with_seller]

--- a/spec/features/admin_buyer_management_spec.rb
+++ b/spec/features/admin_buyer_management_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Managing buyers', type: :feature, js: true do
   describe 'as an admin user', user: :admin_user do
     it 'can deactivate a buyer' do
       buyer = create(:active_buyer)
+      create(:approved_buyer_application, buyer: buyer)
 
       visit '/ops'
       click_on 'Buyers'

--- a/spec/features/admin_buyer_review_spec.rb
+++ b/spec/features/admin_buyer_review_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Reviewing buyer applications', type: :feature, js: true do
       click_on 'Buyer applications'
       click_on 'Reset filters'
 
-      select_application_from_list(application.buyer.name)
+      select_application_from_list(application.name)
 
       expect_application_state('awaiting_assignment')
 
@@ -20,8 +20,8 @@ RSpec.describe 'Reviewing buyer applications', type: :feature, js: true do
       expect_application_state('ready_for_review')
 
       expect_buyer_details(
-        'Buyer name' => application.buyer.name,
-        'Organisation name' => application.buyer.organisation
+        'Buyer name' => application.name,
+        'Organisation name' => application.organisation
       )
 
       decide_on_application(decision: 'Approve', decision_body: 'Response text')

--- a/spec/features/buyer_onboarding_spec.rb
+++ b/spec/features/buyer_onboarding_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'Buyer onboarding', type: :feature, js: true, skip_login: true do
 
-  describe 'as a buyer with a government email' do
-    let(:user) { build(:buyer_user_with_approved_email) }
+  describe 'as a buyer' do
+    let(:user) { build(:buyer_user) }
 
     it 'submits a valid employee application' do
       visit '/register/buyer'
@@ -33,37 +33,6 @@ RSpec.describe 'Buyer onboarding', type: :feature, js: true, skip_login: true do
       # NOTE: All employees now must complete the application form
       fill_in_application_body
 
-      fill_in_employment_status(:contractor)
-      fill_in_manager_details
-      review_and_submit
-
-      expect_submission_message
-    end
-  end
-
-  describe 'as a buyer with a non-government email' do
-    let(:user) { build(:buyer_user_without_approved_email) }
-
-    it 'submits a valid employee application' do
-      visit '/register/buyer'
-
-      complete_buyer_sign_up(user)
-      confirm_email_address(user)
-
-      fill_in_buyer_details
-      fill_in_application_body
-      fill_in_employment_status(:employee)
-      review_and_submit
-    end
-
-    it 'submits a valid contractor application' do
-      visit '/register/buyer'
-
-      complete_buyer_sign_up(user)
-      confirm_email_address(user)
-
-      fill_in_buyer_details
-      fill_in_application_body
       fill_in_employment_status(:contractor)
       fill_in_manager_details
       review_and_submit

--- a/spec/models/buyer_application_spec.rb
+++ b/spec/models/buyer_application_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BuyerApplication do
       let(:application) { create(:buyer_application) }
 
       it 'transitions to `awaiting_manager_approval` when the buyer is a contractor' do
-        application.buyer.employment_status = 'contractor'
+        application.employment_status = 'contractor'
         application.submit
 
         expect(application.state).to eq('awaiting_manager_approval')

--- a/spec/models/slack_message_spec.rb
+++ b/spec/models/slack_message_spec.rb
@@ -14,14 +14,16 @@ RSpec.describe SlackMessage do
   end
 
   it "#new_product_order" do
-    order = build_stubbed(:product_order)
+    application = create(:created_buyer_application)
+    order = create(:product_order, buyer: application.buyer)
+
     buyer_url = admin_buyer_url(order.buyer)
     product_url = pathway_product_url(order.product.section, order.product)
     order_url = admin_product_orders_url
 
     s = SlackMessage.new
     expect(s).to receive(:message).with(
-      text: "<#{buyer_url}|Buyer Buyer> from Organisation Name wants to buy <#{product_url}|Product name>. :moneyBag: :tada:",
+      text: "<#{buyer_url}|#{application.name}> from #{application.organisation} wants to buy <#{product_url}|Product name>. :moneyBag: :tada:",
       attachments: [{
         fallback: "View product order at #{order_url}",
         actions: [
@@ -40,7 +42,7 @@ RSpec.describe SlackMessage do
 
     s = SlackMessage.new
     expect(s).to receive(:message).with(
-      text: "Buyer Buyer from Organisation Name just submitted an application to become a buyer. :saxophone: :tada:",
+      text: "#{application.name} from #{application.organisation} just submitted an application to become a buyer. :saxophone: :tada:",
       attachments: [{
         fallback: "Review application at #{application_url}",
         actions: [


### PR DESCRIPTION
This is the first step of a plan to merge the `Buyer` and `BuyerApplication` models. 

This migrates the existing fields in the `Buyer` model to `BuyerApplication`, simplifies the tests and factories, and adds some aliases for the old methods.