### PR TITLE
Drop the buyers table

### DIFF
--- a/db/migrate/20180808002743_remove_buyers_table.rb
+++ b/db/migrate/20180808002743_remove_buyers_table.rb
@@ -1,0 +1,13 @@
+class RemoveBuyersTable < ActiveRecord::Migration[5.1]
+  def change
+    drop_table :buyers do |t|
+      t.integer :user_id
+      t.string :organisation
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.string :state, null: false
+      t.string :name
+      t.string :employment_status
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180807060320) do
+ActiveRecord::Schema.define(version: 20180808002743) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,16 +35,6 @@ ActiveRecord::Schema.define(version: 20180807060320) do
     t.string "organisation"
     t.string "employment_status"
     t.integer "user_id"
-  end
-
-  create_table "buyers", force: :cascade do |t|
-    t.integer "user_id"
-    t.string "organisation"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "state", null: false
-    t.string "name"
-    t.string "employment_status"
   end
 
   create_table "documents", force: :cascade do |t|


### PR DESCRIPTION
Once the changes in #314 have been deployed, we can go ahead and drop the `buyers` table.

Data in this table was migrated to `buyer_applications` in #313.