### PR TITLE
Display buttons inline in the mailer template

### DIFF
--- a/app/assets/stylesheets/layout/mailer.scss
+++ b/app/assets/stylesheets/layout/mailer.scss
@@ -16,6 +16,8 @@ body.mailer {
 
   a.button {
     @include button;
+    display: inline-block;
+    width: auto;
   }
 
   .quote {


### PR DESCRIPTION
Before:
<img width="1440" alt="Before" src="https://user-images.githubusercontent.com/71922/43877918-a573a356-9bdf-11e8-9735-957bcc592707.png">

After:
<img width="596" alt="After" src="https://user-images.githubusercontent.com/71922/43877922-a7e411ac-9bdf-11e8-891a-fe173c7ff7af.png">
