### PR TITLE
Allow approved sellers to be reverted

### DIFF
--- a/app/controllers/admin/seller_versions_controller.rb
+++ b/app/controllers/admin/seller_versions_controller.rb
@@ -49,6 +49,20 @@ class Admin::SellerVersionsController < Admin::BaseController
     end
   end
 
+  def revert
+    operation = Admin::RevertSellerVersion.call(
+      seller_version_id: params[:id],
+      current_user: current_user,
+    )
+
+    if operation.success?
+      flash.notice = I18n.t("admin.seller_versions.messages.revert_success")
+      return redirect_to admin_seller_application_path(application)
+    else
+      render :show
+    end
+  end
+
   def notes
     application = SellerVersion.find(params[:id])
     event = Event::Note.create(

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -37,6 +37,8 @@ module Event
     end
   end
 
+  class RevertedApplication < Event; end
+
   class ManagerApproved < Event
     def message
       I18n.t(locale_name, name: name, email: email)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -12,7 +12,7 @@ class Product < ApplicationRecord
   has_many :benefits, class_name: 'ProductBenefit'
   has_many :features, class_name: 'ProductFeature'
   has_many :seller_versions, through: :seller, source: :versions
-  
+
   has_one :approved_seller_version, through: :seller, source: :approved_version
 
   aasm column: :state do
@@ -21,6 +21,10 @@ class Product < ApplicationRecord
 
     event :make_active do
       transitions from: :inactive, to: :active
+    end
+
+    event :make_inactive do
+      transitions from: :active, to: :inactive
     end
   end
 

--- a/app/models/seller_version.rb
+++ b/app/models/seller_version.rb
@@ -52,7 +52,7 @@ class SellerVersion < ApplicationRecord
     end
 
     event :return_to_applicant do
-      transitions from: :ready_for_review, to: :created
+      transitions from: [:ready_for_review, :approved], to: :created
     end
   end
 

--- a/app/services/admin/revert_seller_version.rb
+++ b/app/services/admin/revert_seller_version.rb
@@ -1,0 +1,65 @@
+class Admin::RevertSellerVersion < ApplicationService
+  def initialize(seller_version_id:, current_user:)
+    @seller_version_id = seller_version_id
+    @current_user = current_user
+  end
+
+  def seller_version
+    @seller_version ||= SellerVersion.find(seller_version_id)
+  end
+
+  def call
+    begin
+      ActiveRecord::Base.transaction do
+        validate_current_user
+        validate_state
+        update_version_state
+        update_product_states
+        persist_version
+        log_event
+      end
+
+      self.state = :success
+    rescue Failure
+      self.state = :failure
+    end
+  end
+
+private
+  attr_reader :seller_version_id, :current_user
+
+  def products
+    seller_version.seller.products
+  end
+
+  def validate_current_user
+    unless current_user.present? && seller_version.assigned_to == current_user
+      raise Failure
+    end
+  end
+
+  def validate_state
+    unless seller_version.approved? && seller_version.may_return_to_applicant?
+      raise Failure
+    end
+  end
+
+  def update_version_state
+    seller_version.return_to_applicant
+  end
+
+  def update_product_states
+    products.active.each(&:make_inactive!)
+  end
+
+  def persist_version
+    raise Failure unless seller_version.save
+  end
+
+  def log_event
+    Event::RevertedApplication.create(
+      user: current_user,
+      eventable: seller_version,
+    )
+  end
+end

--- a/app/views/admin/buyer_applications/_deactivate_form.html.erb
+++ b/app/views/admin/buyer_applications/_deactivate_form.html.erb
@@ -3,6 +3,6 @@
 <p>If you need to re-activate the account, please contact the <strong>buy.nsw</strong> team for help.</p>
 
 <%= button_to 'Deactivate buyer',
-              deactivate_admin_buyer_application_path,
+              deactivate_admin_buyer_application_path(application),
               class: 'btn btn-danger',
               data: { method: :post } %>

--- a/app/views/admin/seller_versions/_revert_form.html.erb
+++ b/app/views/admin/seller_versions/_revert_form.html.erb
@@ -1,0 +1,10 @@
+<p>
+  This will deactivate the seller and their products from buy.nsw, so that the seller can make changes.
+  When re-submitted, the application and products will need to be reviewed again.
+</p>
+<p>Talk with the seller first before making this change.</p>
+
+<%= button_to 'Deactivate seller and revert for changes',
+              revert_admin_seller_application_path(application),
+              class: 'btn btn-danger',
+              data: { method: :post } %>

--- a/app/views/admin/seller_versions/show.html.erb
+++ b/app/views/admin/seller_versions/show.html.erb
@@ -54,6 +54,16 @@
     </section>
   <% end %>
 
+  <% if application.may_return_to_applicant? && application.approved? && application.assigned_to == current_user %>
+    <section class="make-decision" data-module="collapsible-section">
+      <h2>Revert this application for changes</h2>
+
+      <div class="inner">
+        <%= render partial: 'revert_form' %>
+      </div>
+    </section>
+  <% end %>
+
   <section class="add-note" data-module="collapsible-section">
     <h2>Add a private note to this application</h2>
 

--- a/config/locales/admin/en.yml
+++ b/config/locales/admin/en.yml
@@ -187,6 +187,7 @@ en:
           approve: Application approved
           reject: Application rejected
           return_to_applicant: Application returned to the seller
+        revert_success: Seller and products reverted
     waiting_sellers:
       search:
         filters:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,6 +221,7 @@ en:
       approved_application: "Approved application. Response: %{note}"
       rejected_application: "Rejected application. Response: %{note}"
       returned_application: "Returned application to seller. Response: %{note}"
+      reverted_application: "Deactivated seller and reverted application for changes"
       note: "Note added: %{note}"
   slack_messages:
     new_product_order:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,7 @@ Rails.application.routes.draw do
         patch :assign
         patch :decide
         post :notes
+        post :revert
       end
 
       resources :products, only: :show, controller: 'seller_versions/products'

--- a/spec/features/admin_seller_management_spec.rb
+++ b/spec/features/admin_seller_management_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe 'Managing sellers', type: :feature, js: true do
+
+  describe 'as an admin user', user: :admin_user do
+    it 'can revert a seller' do
+      seller = create(:approved_seller_version, assigned_to: @user)
+
+      visit admin_seller_applications_path
+      click_on 'Reset filters'
+
+      select_seller_from_list(seller.name)
+      expect_seller_state('approved')
+      deactivate_seller
+
+      expect_flash_message(
+        I18n.t('admin.seller_versions.messages.revert_success')
+      )
+      expect_seller_state('created')
+    end
+  end
+
+  def select_seller_from_list(seller_name)
+    within '.record-list table' do
+      row = page.find('td', text: seller_name).ancestor('tr')
+
+      within row do
+        click_on 'View'
+      end
+    end
+  end
+
+  def deactivate_seller
+    page.find('h2', text: 'Revert this application').click
+    click_on 'Deactivate'
+  end
+
+  def expect_seller_state(state)
+    within '.status-indicator' do
+      expect(page).to have_content(state)
+    end
+  end
+
+  def expect_flash_message(message)
+    within '.messages' do
+      expect(page).to have_content(message)
+    end
+  end
+
+end

--- a/spec/services/admin/revert_seller_version_spec.rb
+++ b/spec/services/admin/revert_seller_version_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Admin::RevertSellerVersion do
+
+  let(:current_user) { create(:admin_user) }
+  let(:version) { create(:approved_seller_version, assigned_to: current_user) }
+  let!(:product) { create(:active_product, seller: version.seller) }
+
+  describe '.call' do
+    def perform_operation
+      described_class.call(
+        seller_version_id: version.id,
+        current_user: current_user,
+      )
+    end
+
+    context 'with valid attributes' do
+      let!(:operation) { perform_operation }
+
+      it 'is successful' do
+        expect(operation).to be_success
+        expect(operation).to_not be_failure
+      end
+
+      it 'transitions to the "created" state' do
+        expect(operation.seller_version.state).to eq('created')
+      end
+
+      it 'logs an event' do
+        expect(version.events.first.user).to eq(current_user)
+        expect(version.events.first.message).to match('Deactivated seller')
+      end
+
+      it 'makes the products inactive' do
+        expect(product.reload.state).to eq('inactive')
+      end
+    end
+
+    context 'a version in another state' do
+      let(:version) { create(:created_seller_version, assigned_to: current_user) }
+      let!(:operation) { perform_operation }
+
+      it 'fails' do
+        expect(operation).to be_failure
+      end
+    end
+
+    context 'when the user is not assigned' do
+      let(:version) { create(:approved_seller_version, assigned_to: create(:user)) }
+      let!(:operation) { perform_operation }
+
+      it 'fails' do
+        expect(operation).to be_failure
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This allows administrators to revert sellers after they have been approved. 

It's a short-term fix for situations where sellers need to change their details after they have been approved, which will suffice until future work to build a user interface for self-service change of details (including versioning) has been completed.