### PR TITLE
Make the Seller inactive when the SellerVersion is reverted

### DIFF
--- a/app/models/seller.rb
+++ b/app/models/seller.rb
@@ -21,6 +21,10 @@ class Seller < ApplicationRecord
     event :make_active do
       transitions from: :inactive, to: :active
     end
+
+    event :make_inactive do
+      transitions from: :active, to: :inactive
+    end
   end
 
   def version_in_progress?

--- a/app/services/admin/revert_seller_version.rb
+++ b/app/services/admin/revert_seller_version.rb
@@ -14,6 +14,7 @@ class Admin::RevertSellerVersion < ApplicationService
         validate_current_user
         validate_state
         update_version_state
+        update_seller_state
         update_product_states
         persist_version
         log_event
@@ -28,8 +29,12 @@ class Admin::RevertSellerVersion < ApplicationService
 private
   attr_reader :seller_version_id, :current_user
 
+  def seller
+    seller_version.seller
+  end
+
   def products
-    seller_version.seller.products
+    seller.products
   end
 
   def validate_current_user
@@ -46,6 +51,10 @@ private
 
   def update_version_state
     seller_version.return_to_applicant
+  end
+
+  def update_seller_state
+    seller.make_inactive!
   end
 
   def update_product_states

--- a/spec/services/admin/revert_seller_version_spec.rb
+++ b/spec/services/admin/revert_seller_version_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe Admin::RevertSellerVersion do
       it 'makes the products inactive' do
         expect(product.reload.state).to eq('inactive')
       end
+
+      it 'makes the seller inactive' do
+        expect(version.seller.reload.state).to eq('inactive')
+      end
     end
 
     context 'a version in another state' do


### PR DESCRIPTION
This updates the service object added in #322 so that the `Seller` model is also made inactive when the `SellerVersion` is reverted.

It's important that this happens, otherwise subsequent approvals for the same `Seller` will fail due to the `Seller` already being active.