### PR TITLE
Drop tables and remove models for product features and benefits

### DIFF
--- a/app/models/product_benefit.rb
+++ b/app/models/product_benefit.rb
@@ -1,3 +1,0 @@
-class ProductBenefit < ApplicationRecord
-  belongs_to :product
-end

--- a/app/models/product_feature.rb
+++ b/app/models/product_feature.rb
@@ -1,3 +1,0 @@
-class ProductFeature < ApplicationRecord
-  belongs_to :product
-end

--- a/db/migrate/20180814001945_drop_product_features_benefits_tables.rb
+++ b/db/migrate/20180814001945_drop_product_features_benefits_tables.rb
@@ -1,0 +1,13 @@
+class DropProductFeaturesBenefitsTables < ActiveRecord::Migration[5.1]
+  def change
+    drop_table :product_features do |t|
+      t.integer :product_id, null: false
+      t.string :feature
+    end
+
+    drop_table :product_benefits do |t|
+      t.integer :product_id, null: false
+      t.string :benefit
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180813010727) do
+ActiveRecord::Schema.define(version: 20180814001945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,20 +71,6 @@ ActiveRecord::Schema.define(version: 20180813010727) do
     t.text "tags", default: [], array: true
     t.integer "resolved_by_id"
     t.datetime "resolved_at"
-  end
-
-  create_table "product_benefits", force: :cascade do |t|
-    t.integer "product_id"
-    t.string "benefit"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "product_features", force: :cascade do |t|
-    t.integer "product_id"
-    t.string "feature"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "product_orders", force: :cascade do |t|

--- a/spec/factories/product_benefits.rb
+++ b/spec/factories/product_benefits.rb
@@ -1,6 +1,0 @@
-FactoryBot.define do
-  factory :product_benefit do
-    association :product
-    sequence(:benefit) {|n| "Benefit #{n}" }
-  end
-end

--- a/spec/factories/product_features.rb
+++ b/spec/factories/product_features.rb
@@ -1,6 +1,0 @@
-FactoryBot.define do
-  factory :product_feature do
-    association :product
-    sequence(:feature) {|n| "Feature #{n}" }
-  end
-end


### PR DESCRIPTION
Now that #325 has been deployed to migrate product features and benefits into the `products` table, this removes the old tables and models.