### PR TITLE
Move all remaining forms out of the 'concepts' directory

### DIFF
--- a/app/concepts/buyers/buyer_application/operation/update.rb
+++ b/app/concepts/buyers/buyer_application/operation/update.rb
@@ -14,19 +14,19 @@ class Buyers::BuyerApplication::Update < Trailblazer::Operation
       end
 
       step_flow do |application|
-        step Buyers::BuyerApplication::Contract::BasicDetails
+        step BuyerApplications::BasicDetailsForm
 
         if application.requires_email_approval?
-          step Buyers::BuyerApplication::Contract::EmailApproval
+          step BuyerApplications::EmailApprovalForm
         end
 
-        step Buyers::BuyerApplication::Contract::EmploymentStatus
+        step BuyerApplications::EmploymentStatusForm
 
         if application.requires_manager_approval?
-          step Buyers::BuyerApplication::Contract::ManagerApproval
+          step BuyerApplications::ManagerApprovalForm
         end
 
-        step Buyers::BuyerApplication::Contract::Terms
+        step BuyerApplications::TermsForm
       end
     end
   end

--- a/app/concepts/concerns/operations/multi_step_form/step.rb
+++ b/app/concepts/concerns/operations/multi_step_form/step.rb
@@ -20,8 +20,12 @@ module Concerns::Operations::MultiStepForm
       I18n.t("#{i18n_key}.steps.#{key}.button_label", default: default)
     end
 
+    def i18n_base
+      "#{i18n_key}.steps.#{key}"
+    end
+
     def key
-      contract_class.name.demodulize.underscore
+      contract_class.name.demodulize.sub(/Form$/,'').underscore
     end
 
     def slug

--- a/app/concepts/sellers/seller_version/invitation/operation/accept.rb
+++ b/app/concepts/sellers/seller_version/invitation/operation/accept.rb
@@ -1,7 +1,7 @@
 class Sellers::SellerVersion::Invitation::Accept < Trailblazer::Operation
   class Present < Trailblazer::Operation
     step :validate_confirmation_token!
-    step Contract::Build( constant: Sellers::SellerVersion::Invitation::Contract::Accept )
+    step Contract::Build( constant: Sellers::AcceptInvitationForm )
 
     def validate_confirmation_token!(options, params:, **)
       options[:application_model] = SellerVersion.created.find_by_id(params[:application_id])

--- a/app/concepts/sellers/seller_version/invitation/operation/create.rb
+++ b/app/concepts/sellers/seller_version/invitation/operation/create.rb
@@ -2,7 +2,7 @@ class Sellers::SellerVersion::Invitation::Create < Trailblazer::Operation
   class Present < Trailblazer::Operation
     step :application_model!
     step :build_user!
-    step Contract::Build( constant: Sellers::SellerVersion::Invitation::Contract::Create )
+    step Contract::Build( constant: Sellers::CreateInvitationForm )
 
     def application_model!(options, params:, **)
       options[:application_model] = options['config.current_user'].seller_versions.find(params[:application_id])

--- a/app/concepts/sellers/waiting_seller/operation/accept.rb
+++ b/app/concepts/sellers/waiting_seller/operation/accept.rb
@@ -1,7 +1,7 @@
 class Sellers::WaitingSeller::Accept < Trailblazer::Operation
   class Present < Trailblazer::Operation
     step :model!
-    step Contract::Build( constant: Sellers::WaitingSeller::Contract::Accept )
+    step Contract::Build( constant: Sellers::AcceptWaitingSellerForm )
     success :setup_errors
     step :check_user_does_not_exist!
     step :check_seller_does_not_exist!, fail_fast: true

--- a/app/forms/admin/assign_buyer_application_form.rb
+++ b/app/forms/admin/assign_buyer_application_form.rb
@@ -1,8 +1,8 @@
-module Admin::SellerVersion::Contract
-  class Assign < Reform::Form
+module Admin
+  class AssignBuyerApplicationForm < Reform::Form
     include Forms::ValidationHelper
 
-    model :seller_application
+    model :buyer_application
 
     property :assigned_to_id
 

--- a/app/forms/admin/assign_seller_version_form.rb
+++ b/app/forms/admin/assign_seller_version_form.rb
@@ -1,8 +1,8 @@
-module Admin::BuyerApplication::Contract
-  class Assign < Reform::Form
+module Admin
+  class AssignSellerVersionForm < Reform::Form
     include Forms::ValidationHelper
 
-    model :buyer_application
+    model :seller_application
 
     property :assigned_to_id
 

--- a/app/forms/admin/decide_buyer_application_form.rb
+++ b/app/forms/admin/decide_buyer_application_form.rb
@@ -1,11 +1,11 @@
-module Admin::SellerVersion::Contract
-  class Decide < Reform::Form
+module Admin
+  class DecideBuyerApplicationForm < Reform::Form
     include Forms::ValidationHelper
 
-    model :seller_application
+    model :buyer_application
 
     property :decision, virtual: true
-    property :response
+    property :decision_body
 
     validation :default, inherit: true do
       required(:decision).filled(in_list?: ['approve', 'reject', 'return_to_applicant'])

--- a/app/forms/admin/decide_seller_version_form.rb
+++ b/app/forms/admin/decide_seller_version_form.rb
@@ -1,11 +1,11 @@
-module Admin::BuyerApplication::Contract
-  class Decide < Reform::Form
+module Admin
+  class DecideSellerVersionForm < Reform::Form
     include Forms::ValidationHelper
 
-    model :buyer_application
+    model :seller_application
 
     property :decision, virtual: true
-    property :decision_body
+    property :response
 
     validation :default, inherit: true do
       required(:decision).filled(in_list?: ['approve', 'reject', 'return_to_applicant'])

--- a/app/forms/admin/tag_problem_report_form.rb
+++ b/app/forms/admin/tag_problem_report_form.rb
@@ -1,5 +1,5 @@
-module Admin::ProblemReport::Contract
-  class Tag < Reform::Form
+module Admin
+  class TagProblemReportForm < Reform::Form
     property :tags
 
     def tags=(string)

--- a/app/forms/admin/update_waiting_seller_form.rb
+++ b/app/forms/admin/update_waiting_seller_form.rb
@@ -1,5 +1,5 @@
-module Admin::WaitingSeller::Contract
-  class Update < Reform::Form
+module Admin
+  class UpdateWaitingSellerForm < Reform::Form
     include Forms::ValidationHelper
 
     property :name

--- a/app/forms/buyer_applications/base_form.rb
+++ b/app/forms/buyer_applications/base_form.rb
@@ -1,5 +1,5 @@
-module Buyers::BuyerApplication::Contract
-  class Base < Reform::Form
+module BuyerApplications
+  class BaseForm < Reform::Form
     include Concerns::Contracts::Status
     include Forms::ValidationHelper
 

--- a/app/forms/buyer_applications/base_form.rb
+++ b/app/forms/buyer_applications/base_form.rb
@@ -1,6 +1,6 @@
 module BuyerApplications
   class BaseForm < Reform::Form
-    include Concerns::Contracts::Status
+    include Concerns::FormStatus
     include Forms::ValidationHelper
 
     def i18n_base

--- a/app/forms/buyer_applications/basic_details_form.rb
+++ b/app/forms/buyer_applications/basic_details_form.rb
@@ -1,5 +1,5 @@
-module Buyers::BuyerApplication::Contract
-  class BasicDetails < Base
+module BuyerApplications
+  class BasicDetailsForm < BaseForm
     property :name
     property :organisation
 

--- a/app/forms/buyer_applications/email_approval_form.rb
+++ b/app/forms/buyer_applications/email_approval_form.rb
@@ -1,5 +1,5 @@
-module Buyers::BuyerApplication::Contract
-  class EmailApproval < Base
+module BuyerApplications
+  class EmailApprovalForm < BaseForm
     property :application_body
 
     validation :default do

--- a/app/forms/buyer_applications/employment_status_form.rb
+++ b/app/forms/buyer_applications/employment_status_form.rb
@@ -1,5 +1,5 @@
-module Buyers::BuyerApplication::Contract
-  class EmploymentStatus < Base
+module BuyerApplications
+  class EmploymentStatusForm < BaseForm
     property :employment_status
 
     validation :default, inherit: true do

--- a/app/forms/buyer_applications/manager_approval_form.rb
+++ b/app/forms/buyer_applications/manager_approval_form.rb
@@ -1,5 +1,5 @@
-module Buyers::BuyerApplication::Contract
-  class ManagerApproval < Base
+module BuyerApplications
+  class ManagerApprovalForm < BaseForm
     property :manager_name
     property :manager_email
 

--- a/app/forms/buyer_applications/terms_form.rb
+++ b/app/forms/buyer_applications/terms_form.rb
@@ -1,5 +1,5 @@
-module Buyers::BuyerApplication::Contract
-  class Terms < Base
+module BuyerApplications
+  class TermsForm < BaseForm
     def valid?
       true
     end

--- a/app/forms/concerns/form_status.rb
+++ b/app/forms/concerns/form_status.rb
@@ -1,4 +1,4 @@
-module Concerns::Contracts::Status
+module Concerns::FormStatus
   extend ActiveSupport::Concern
 
   def started?(&block)

--- a/app/forms/concerns/nested_text_field_array.rb
+++ b/app/forms/concerns/nested_text_field_array.rb
@@ -1,4 +1,4 @@
-module Concerns::Contracts::Populators
+module Concerns::NestedTextFieldArray
   TextFieldArrayPrepopulator = ->(context, name:, limit:) {
     context.send("#{name}=", []) unless context.send(name).is_a?(Array)
 

--- a/app/forms/products/base_form.rb
+++ b/app/forms/products/base_form.rb
@@ -1,6 +1,6 @@
 module Products
   class BaseForm < Reform::Form
-    include Concerns::Contracts::Status
+    include Concerns::FormStatus
     include Forms::ValidationHelper
 
     def product_id

--- a/app/forms/products/basics_form.rb
+++ b/app/forms/products/basics_form.rb
@@ -1,6 +1,6 @@
 module Products
   class BasicsForm < BaseForm
-    include Concerns::Contracts::Populators
+    include Concerns::NestedTextFieldArray
 
     def features=(array)
       super(filter_blank_array_values(array))

--- a/app/forms/seller_versions/addresses_form.rb
+++ b/app/forms/seller_versions/addresses_form.rb
@@ -1,6 +1,6 @@
 module SellerVersions
   class AddressesForm < BaseForm
-    include Concerns::Contracts::Populators
+    include Concerns::NestedTextFieldArray
     include Forms::ValidationHelper
 
     AddressPrepopulator = ->(_) {

--- a/app/forms/seller_versions/base_form.rb
+++ b/app/forms/seller_versions/base_form.rb
@@ -1,6 +1,6 @@
 module SellerVersions
   class BaseForm < Reform::Form
-    include Concerns::Contracts::Status
+    include Concerns::FormStatus
     include Forms::ValidationHelper
 
     def upload_for(key)

--- a/app/forms/seller_versions/recognition_form.rb
+++ b/app/forms/seller_versions/recognition_form.rb
@@ -1,6 +1,6 @@
 module SellerVersions
   class RecognitionForm < BaseForm
-    include Concerns::Contracts::Populators
+    include Concerns::NestedTextFieldArray
 
     def accreditations=(array)
       super(filter_blank_array_values(array))

--- a/app/forms/sellers/accept_invitation_form.rb
+++ b/app/forms/sellers/accept_invitation_form.rb
@@ -1,5 +1,5 @@
-module Sellers::SellerVersion::Invitation::Contract
-  class Accept < Reform::Form
+module Sellers
+  class AcceptInvitationForm < Reform::Form
     property :password
     property :password_confirmation, virtual: true
 

--- a/app/forms/sellers/accept_waiting_seller_form.rb
+++ b/app/forms/sellers/accept_waiting_seller_form.rb
@@ -1,5 +1,5 @@
-module Sellers::WaitingSeller::Contract
-  class Accept < Reform::Form
+module Sellers
+  class AcceptWaitingSellerForm < Reform::Form
     property :password, virtual: true
     property :password_confirmation, virtual: true
   end

--- a/app/forms/sellers/create_invitation_form.rb
+++ b/app/forms/sellers/create_invitation_form.rb
@@ -1,5 +1,5 @@
-module Sellers::SellerVersion::Invitation::Contract
-  class Create < Reform::Form
+module Sellers
+  class CreateInvitationForm < Reform::Form
     include Forms::ValidationHelper
 
     property :email

--- a/app/services/admin/build_assign_buyer_application.rb
+++ b/app/services/admin/build_assign_buyer_application.rb
@@ -12,7 +12,7 @@ class Admin::BuildAssignBuyerApplication < ApplicationService
   end
 
   def form
-    @form ||= Admin::BuyerApplication::Contract::Assign.new(buyer_application)
+    @form ||= Admin::AssignBuyerApplicationForm.new(buyer_application)
   end
 
   def buyer_application

--- a/app/services/admin/build_assign_seller_version.rb
+++ b/app/services/admin/build_assign_seller_version.rb
@@ -12,7 +12,7 @@ class Admin::BuildAssignSellerVersion < ApplicationService
   end
 
   def form
-    @form ||= Admin::SellerVersion::Contract::Assign.new(seller_version)
+    @form ||= Admin::AssignSellerVersionForm.new(seller_version)
   end
 
   def seller_version

--- a/app/services/admin/build_decide_buyer_application.rb
+++ b/app/services/admin/build_decide_buyer_application.rb
@@ -12,7 +12,7 @@ class Admin::BuildDecideBuyerApplication < ApplicationService
   end
 
   def form
-    @form ||= Admin::BuyerApplication::Contract::Decide.new(buyer_application)
+    @form ||= Admin::DecideBuyerApplicationForm.new(buyer_application)
   end
 
   def buyer_application

--- a/app/services/admin/build_decide_seller_version.rb
+++ b/app/services/admin/build_decide_seller_version.rb
@@ -12,7 +12,7 @@ class Admin::BuildDecideSellerVersion < ApplicationService
   end
 
   def form
-    @form ||= Admin::SellerVersion::Contract::Decide.new(seller_version)
+    @form ||= Admin::DecideSellerVersionForm.new(seller_version)
   end
 
   def seller_version

--- a/app/services/admin/build_invite_waiting_sellers.rb
+++ b/app/services/admin/build_invite_waiting_sellers.rb
@@ -32,7 +32,7 @@ private
   attr_reader :waiting_seller_ids
 
   def form_class
-    Admin::WaitingSeller::Contract::Update
+    Admin::UpdateWaitingSellerForm
   end
 
   def valid_waiting_sellers?

--- a/app/services/admin/build_tag_problem_report.rb
+++ b/app/services/admin/build_tag_problem_report.rb
@@ -13,7 +13,7 @@ class Admin::BuildTagProblemReport < ApplicationService
   end
 
   def form
-    @form ||= Admin::ProblemReport::Contract::Tag.new(problem_report)
+    @form ||= Admin::TagProblemReportForm.new(problem_report)
   end
 
   def problem_report

--- a/app/services/admin/build_update_waiting_seller.rb
+++ b/app/services/admin/build_update_waiting_seller.rb
@@ -19,7 +19,7 @@ class Admin::BuildUpdateWaitingSeller < ApplicationService
   end
 
   def form
-    @form ||= Admin::WaitingSeller::Contract::Update.new(waiting_seller)
+    @form ||= Admin::UpdateWaitingSellerForm.new(waiting_seller)
   end
 
 private

--- a/app/views/buyers/applications/show.html.erb
+++ b/app/views/buyers/applications/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= operation['result.step'].name(:long) %></h1>
 
-<%= buy_nsw_form_for form, url: buyers_application_path(application), as: :buyer_application do |f| %>
+<%= buy_nsw_form_for form, url: buyers_application_path(application), as: :buyer_application, i18n_scope: operation['result.step'].i18n_base do |f| %>
   <%= display_block_errors(f) %>
 
   <%= render partial: operation['result.step'].key, locals: { f: f, operation: operation } %>

--- a/spec/forms/admin/assign_buyer_application_form_spec.rb
+++ b/spec/forms/admin/assign_buyer_application_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Admin::BuyerApplication::Contract::Assign do
+RSpec.describe Admin::AssignBuyerApplicationForm do
 
   let(:user) { create(:admin_user) }
   let(:application) { build_stubbed(:buyer_application) }

--- a/spec/forms/admin/assign_seller_version_form_spec.rb
+++ b/spec/forms/admin/assign_seller_version_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Admin::SellerVersion::Contract::Assign do
+RSpec.describe Admin::AssignSellerVersionForm do
 
   let(:user) { create(:admin_user) }
   let(:application) { build_stubbed(:seller_version) }

--- a/spec/forms/admin/decide_buyer_application_form_spec.rb
+++ b/spec/forms/admin/decide_buyer_application_form_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-RSpec.describe Admin::SellerVersion::Contract::Decide do
+RSpec.describe Admin::DecideBuyerApplicationForm do
 
-  let(:application) { build_stubbed(:seller_version) }
+  let(:application) { build_stubbed(:buyer_application) }
 
-  it 'is valid with a decision and response' do
+  it 'is valid with a decision and decision_body' do
     form = described_class.new(application)
 
     form.validate(
        decision: 'approve',
-       response: 'Response',
+       decision_body: 'Response',
     )
 
     expect(form).to be_valid

--- a/spec/forms/admin/decide_seller_version_form_spec.rb
+++ b/spec/forms/admin/decide_seller_version_form_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-RSpec.describe Admin::BuyerApplication::Contract::Decide do
+RSpec.describe Admin::DecideSellerVersionForm do
 
-  let(:application) { build_stubbed(:buyer_application) }
+  let(:application) { build_stubbed(:seller_version) }
 
-  it 'is valid with a decision and decision_body' do
+  it 'is valid with a decision and response' do
     form = described_class.new(application)
 
     form.validate(
        decision: 'approve',
-       decision_body: 'Response',
+       response: 'Response',
     )
 
     expect(form).to be_valid

--- a/spec/forms/admin/tag_problem_report_form_spec.rb
+++ b/spec/forms/admin/tag_problem_report_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Admin::ProblemReport::Contract::Tag do
+RSpec.describe Admin::TagProblemReportForm do
 
   let(:problem_report) { build_stubbed(:open_problem_report) }
 

--- a/spec/forms/admin/update_waiting_seller_form_spec.rb
+++ b/spec/forms/admin/update_waiting_seller_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Admin::WaitingSeller::Contract::Update do
+RSpec.describe Admin::UpdateWaitingSellerForm do
 
   let(:waiting_seller) { build_stubbed(:waiting_seller) }
   let(:atts) { attributes_for(:waiting_seller) }

--- a/spec/forms/sellers/accept_invitation_form_spec.rb
+++ b/spec/forms/sellers/accept_invitation_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Sellers::SellerVersion::Invitation::Contract::Accept do
+RSpec.describe Sellers::AcceptInvitationForm do
   let(:application) { build_stubbed(:seller_version) }
   let(:user) { build_stubbed(:seller_user, seller: application.seller) }
 

--- a/spec/forms/sellers/create_invitation_form_spec.rb
+++ b/spec/forms/sellers/create_invitation_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Sellers::SellerVersion::Invitation::Contract::Create do
+RSpec.describe Sellers::CreateInvitationForm do
   let(:application) { build_stubbed(:seller_version) }
   let(:user) { build_stubbed(:seller_user, seller: application.seller) }
 

--- a/spec/services/admin/build_assign_buyer_application_spec.rb
+++ b/spec/services/admin/build_assign_buyer_application_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Admin::BuildAssignBuyerApplication do
 
   describe '#form' do
     it 'returns a form for the buyer application' do
-      expect(subject.form).to be_a(Admin::BuyerApplication::Contract::Assign)
+      expect(subject.form).to be_a(Admin::AssignBuyerApplicationForm)
       expect(subject.form.model).to eq(application)
     end
   end

--- a/spec/services/admin/build_assign_seller_version_spec.rb
+++ b/spec/services/admin/build_assign_seller_version_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Admin::BuildAssignSellerVersion do
 
   describe '#form' do
     it 'returns a form for the seller version' do
-      expect(subject.form).to be_a(Admin::SellerVersion::Contract::Assign)
+      expect(subject.form).to be_a(Admin::AssignSellerVersionForm)
       expect(subject.form.model).to eq(version)
     end
   end

--- a/spec/services/admin/build_decide_buyer_application_spec.rb
+++ b/spec/services/admin/build_decide_buyer_application_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Admin::BuildDecideBuyerApplication do
 
   describe '#form' do
     it 'returns a form for the buyer application' do
-      expect(subject.form).to be_a(Admin::BuyerApplication::Contract::Decide)
+      expect(subject.form).to be_a(Admin::DecideBuyerApplicationForm)
       expect(subject.form.model).to eq(application)
     end
   end

--- a/spec/services/admin/build_decide_seller_version_spec.rb
+++ b/spec/services/admin/build_decide_seller_version_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Admin::BuildDecideSellerVersion do
 
   describe '#form' do
     it 'returns a form for the seller version' do
-      expect(subject.form).to be_a(Admin::SellerVersion::Contract::Decide)
+      expect(subject.form).to be_a(Admin::DecideSellerVersionForm)
       expect(subject.form.model).to eq(version)
     end
   end

--- a/spec/services/admin/build_tag_problem_report_spec.rb
+++ b/spec/services/admin/build_tag_problem_report_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Admin::BuildTagProblemReport do
 
   describe '#form' do
     it 'returns a form for the problem report' do
-      expect(subject.form).to be_a(Admin::ProblemReport::Contract::Tag)
+      expect(subject.form).to be_a(Admin::TagProblemReportForm)
       expect(subject.form.model).to eq(problem_report)
     end
   end

--- a/spec/services/admin/build_update_waiting_seller_spec.rb
+++ b/spec/services/admin/build_update_waiting_seller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Admin::BuildUpdateWaitingSeller do
       end
 
       it 'assigns the form' do
-        expect(subject.form).to be_a(Admin::WaitingSeller::Contract::Update)
+        expect(subject.form).to be_a(Admin::UpdateWaitingSellerForm)
         expect(subject.form.model).to eq(waiting_seller)
       end
     end


### PR DESCRIPTION
This finishes the work to move and rename all the remaining forms from the `app/concepts` directory to `app/forms`.