### PR TITLE
Include the application ID when looking up buyer applications

### DIFF
--- a/app/controllers/buyers/applications_controller.rb
+++ b/app/controllers/buyers/applications_controller.rb
@@ -63,7 +63,7 @@ private
   helper_method :operation
 
   def application
-    @application ||= BuyerApplication.created.find_by!(user: current_user)
+    @application ||= BuyerApplication.created.find_by!(user: current_user, id: params[:id])
   end
   helper_method :application
 


### PR DESCRIPTION
The changes in #329 looked up the buyer application through the current user. This meant that you could provide any ID in the URL and it would still work (although still only returning _your own_ application).

This preserves the existing behaviour of failing when the buyer application ID does not match the user, returning a 404.