### PR TITLE
Add first field-cloud_purchase

### DIFF
--- a/app/forms/buyer_applications/email_approval_form.rb
+++ b/app/forms/buyer_applications/email_approval_form.rb
@@ -1,6 +1,8 @@
 module BuyerApplications
   class EmailApprovalForm < BaseForm
     property :application_body
+    property :cloud_purchase
+    property :contactable
 
     validation :default do
       required(:application_body).filled

--- a/app/models/buyer_application.rb
+++ b/app/models/buyer_application.rb
@@ -12,6 +12,8 @@ class BuyerApplication < ApplicationRecord
   has_many :events, -> { order(created_at: :desc) }, as: :eventable, class_name: 'Event::Event'
   has_many :product_orders, foreign_key: :buyer_id
 
+  enumerize :cloud_purchase, in: ['make-purchase', 'plan-purchase', 'no-plan']
+  enumerize :contactable, in: ['phone-number', 'email', 'none']
   enumerize :employment_status, in: ['employee', 'contractor', 'other-eligible']
 
   aasm column: :state do
@@ -99,4 +101,6 @@ class BuyerApplication < ApplicationRecord
 
   scope :assigned_to, ->(user) { where('assigned_to_id = ?', user) }
   scope :for_review, -> { awaiting_assignment.or(ready_for_review) }
+
+
 end

--- a/app/views/buyers/applications/_email_approval.html.erb
+++ b/app/views/buyers/applications/_email_approval.html.erb
@@ -1,1 +1,3 @@
-<%= f.input :application_body, as: :text, input_html: { rows: 5 } %>
+<%= f.input :application_body, as: :text, input_html: { rows: 3 } %>
+
+<%= f.input :cloud_purchase, as: :radio_buttons, collection: BuyerApplication.cloud_purchase.options %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,7 +16,9 @@ en:
         email_approval:
           long: 'Why do you need access?'
           application_body:
-            label: Please write a few lines to tell us why you need an account on buy.nsw.
+            label: We’d like to know more about you and where you’re at in your buying journey. In a few sentences, please tell us how you plan to use buy.nsw.
+          cloud_purchase:
+            label: Are you considering a cloud purchase soon? 
         manager_approval:
           long: 'Approval from your line manager'
           manager_name:
@@ -74,10 +76,19 @@ en:
       unauthenticated: "Please sign in or create an account to continue."
   enumerize:
     buyer_application:
+      cloud_purchase:
+        make-purchase: "Yes, we’re currently looking to make a cloud purchase."
+        plan-purchase: "Yes, we’re planning a cloud purchase in the next six months."
+        no-plan: "We’re not currently planning a cloud purchase."
+      contactable:
+        phone-number: "Sure."
+        email: "I'd prefer email."
+        none: "No thanks."
       employment_status:
         employee: "I'm a NSW Government employee and need access to buy.nsw to perform my role."
         contractor: "I'm a contractor working in state or local government."
         other-eligible: "I'm an employee of another organisation that has registered as an eligible buyer."
+
     document:
       scan_status:
         unscanned: Awaiting virus scan

--- a/db/migrate/20180820050128_add_fields_to_buyer_application.rb
+++ b/db/migrate/20180820050128_add_fields_to_buyer_application.rb
@@ -1,0 +1,7 @@
+class AddFieldsToBuyerApplication < ActiveRecord::Migration[5.1]
+  def change
+    add_column :buyer_applications, :cloud_purchase, :string
+    add_column :buyer_applications, :contactable, :string
+    add_column :buyer_applications, :contact_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180814001945) do
+ActiveRecord::Schema.define(version: 20180820050128) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,9 @@ ActiveRecord::Schema.define(version: 20180814001945) do
     t.string "organisation"
     t.string "employment_status"
     t.integer "user_id"
+    t.string "cloud_purchase"
+    t.string "contactable"
+    t.string "contact_number"
   end
 
   create_table "documents", force: :cascade do |t|

--- a/spec/features/buyer_onboarding_spec.rb
+++ b/spec/features/buyer_onboarding_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Buyer onboarding', type: :feature, js: true, skip_login: true do
 
   def fill_in_application_body
     fill_in 'buyer_application[application_body]', with: 'I am an authorised buyer from another agency'
-
+    choose "Yes, we’re currently looking"
     click_on 'Next'
   end
 


### PR DESCRIPTION
- add migration for fields 'cloud_purchase', 'contactable', 'contact_number'.
- add unit test for spec/features/buyer_onboarding_spec.rb
- add relevant string to localisation file
- add enum in the model 'buyer_application.rb"
- update the form for email application.