### PR TITLE
make seller and buyer_application models discardable

### DIFF
--- a/app/models/buyer_application.rb
+++ b/app/models/buyer_application.rb
@@ -6,6 +6,9 @@ class BuyerApplication < ApplicationRecord
 
   include Concerns::StateScopes
 
+  include Discard::Model
+  default_scope -> { kept }
+
   belongs_to :assigned_to, class_name: 'User', optional: true
   belongs_to :user
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -5,6 +5,9 @@ class Product < ApplicationRecord
   include Concerns::Documentable
   include Concerns::StateScopes
 
+  include Discard::Model
+  default_scope -> { kept }
+
   belongs_to :seller
 
   has_documents :terms

--- a/app/models/seller.rb
+++ b/app/models/seller.rb
@@ -5,6 +5,9 @@ class Seller < ApplicationRecord
   include Concerns::Documentable
   include Concerns::StateScopes
 
+  include Discard::Model
+  default_scope -> { kept }
+
   has_many :owners, class_name: 'User'
   belongs_to :agreed_by, class_name: 'User', optional: true
 
@@ -41,5 +44,11 @@ class Seller < ApplicationRecord
 
   def approved_name
     approved_version&.name
+  end
+
+  after_discard do
+    products.discard_all
+    versions.discard_all
+    owners.discard_all
   end
 end

--- a/app/models/seller_version.rb
+++ b/app/models/seller_version.rb
@@ -5,6 +5,9 @@ class SellerVersion < ApplicationRecord
   include Concerns::StateScopes
   include Concerns::Documentable
 
+  include Discard::Model
+  default_scope -> { kept }
+
   before_save :normalise_abn
 
   belongs_to :seller

--- a/db/migrate/20180906013446_add_discarded_at_to_models.rb
+++ b/db/migrate/20180906013446_add_discarded_at_to_models.rb
@@ -1,0 +1,12 @@
+class AddDiscardedAtToModels < ActiveRecord::Migration[5.1]
+  def change
+    add_column :sellers, :discarded_at, :datetime
+    add_column :seller_versions, :discarded_at, :datetime
+    add_column :products, :discarded_at, :datetime
+    add_column :buyer_applications, :discarded_at, :datetime
+    add_index :sellers, :discarded_at
+    add_index :seller_versions, :discarded_at
+    add_index :products, :discarded_at
+    add_index :buyer_applications, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180903055122) do
+ActiveRecord::Schema.define(version: 20180906013446) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,8 @@ ActiveRecord::Schema.define(version: 20180903055122) do
     t.string "cloud_purchase"
     t.string "contactable"
     t.string "contact_number"
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_buyer_applications_on_discarded_at"
   end
 
   create_table "documents", force: :cascade do |t|
@@ -234,6 +236,8 @@ ActiveRecord::Schema.define(version: 20180903055122) do
     t.integer "terms_id"
     t.text "features", default: [], array: true
     t.text "benefits", default: [], array: true
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_products_on_discarded_at"
   end
 
   create_table "seller_versions", force: :cascade do |t|
@@ -302,12 +306,16 @@ ActiveRecord::Schema.define(version: 20180903055122) do
     t.integer "professional_indemnity_certificate_id"
     t.integer "workers_compensation_certificate_id"
     t.integer "product_liability_certificate_id"
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_seller_versions_on_discarded_at"
   end
 
   create_table "sellers", force: :cascade do |t|
     t.string "state", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_sellers_on_discarded_at"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
updates seller, seller_version, product, and buyer_application models
to be discardable.
adds discarded_at field to above mentioned models in migration
adds after_discard method for seller which cascades a discard to related
 objects
adds after_discard method for user which cascades a discard to a
 buyer_application and a seller (only if the user is the only owner)