### PR TITLE
Case-insensitive compare for AuthRep email to accept Core terms

### DIFF
--- a/app/concepts/sellers/seller_version/operation/update.rb
+++ b/app/concepts/sellers/seller_version/operation/update.rb
@@ -40,7 +40,7 @@ class Sellers::SellerVersion::Update < Trailblazer::Operation
 
         if !options['contract.default'].representative_details_provided?
           errors['missing_representative_details'] = true
-        elsif (current_user_email != representative_email)
+        elsif !(current_user_email.casecmp?(representative_email))
           errors['not_authorised_representative'] = true
         end
         unless options['contract.default'].business_details_provided?


### PR DESCRIPTION
there is a bug that when the authRep email in the Contact list doesn't case sensitive match the authRep's email, even though the authRep logs in, he can't accept the terms.